### PR TITLE
Add CLAUDE.md and cloud-compatible demo Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ releases** should be considered **breaking**!
 ### Components Changes
 
 - add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent` ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
+- feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
 
 ### Demo / Docs Changes
 
@@ -29,12 +30,6 @@ releases** should be considered **breaking**!
   - Added <code>heroku/ruby</code> and <code>heroku/nodejs</code> buildpacks
   - Custom buildpack must run first to ensure files are in place before standard buildpacks execute
 - **Developer Tooling**: Add `CLAUDE.md` at the repo root referencing all Windsurf rule files so Claude Code sessions pick up the same coding conventions as Windsurf ([Fixes #90](https://github.com/profoundry-us/loco_motion/issues/90))
-
-## [Unreleased]
-
-### Added
-
-- feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
 
 ## [0.5.2] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ releases** should be considered **breaking**!
 ### Demo / Docs Changes
 
 - add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image gallery examples
+- add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in network-restricted environments (e.g. Claude Code cloud) where OS package repos are blocked; uses a multi-stage build to copy Node.js from `node:20-slim` instead of installing via `nodesource`
 
 ### Changed
 
@@ -27,6 +28,7 @@ releases** should be considered **breaking**!
   - Added custom <code>loco_motion-buildpack</code> to copy <code>docs/demo</code> subdirectory and gem files
   - Added <code>heroku/ruby</code> and <code>heroku/nodejs</code> buildpacks
   - Custom buildpack must run first to ensure files are in place before standard buildpacks execute
+- **Developer Tooling**: Add `CLAUDE.md` at the repo root referencing all Windsurf rule files so Claude Code sessions pick up the same coding conventions as Windsurf ([Fixes #90](https://github.com/profoundry-us/loco_motion/issues/90))
 
 ## [Unreleased]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project Instructions
+
+@.windsurf/rules/coding.md
+@.windsurf/rules/committing.md
+@.windsurf/rules/communication.md
+@.windsurf/rules/component_implementation.md
+@.windsurf/rules/creating_a_plan.md
+@.windsurf/rules/creating_a_pull_request.md
+@.windsurf/rules/creating_guides.md
+@.windsurf/rules/documenting_code.md
+@.windsurf/rules/generating_a_pr_description.md
+@.windsurf/rules/maintaining_rules.md
+@.windsurf/rules/non_code_documentation.md
+@.windsurf/rules/releasing.md
+@.windsurf/rules/running_commands.md
+@.windsurf/rules/running_playwright_tests.md
+@.windsurf/rules/starting_an_issue.md
+@.windsurf/rules/updating_the_changelog.md
+@.windsurf/rules/writing_playwright_tests.md
+@.windsurf/workflows/new_component_workflow.md

--- a/docs/demo/Dockerfile.demo.cloud
+++ b/docs/demo/Dockerfile.demo.cloud
@@ -1,0 +1,34 @@
+# Cloud-compatible Dockerfile for environments where apt-get is blocked.
+# Uses multi-stage build to copy Node.js from the official node image
+# rather than installing it via apt/nodesource (which requires deb.debian.org).
+#
+# The full ruby:3.4.4 image already includes build-essential, so no apt-get
+# is needed at all.
+
+# Stage 1: grab node + npm + yarn from the official node image
+FROM node:20-slim AS node_source
+
+# Stage 2: main image — ruby:3.4.4 (full, already has build-essential/git/curl)
+FROM ruby:3.4.4
+
+# Copy node, npm, and yarn binaries from the node image
+COPY --from=node_source /usr/local/bin/node /usr/local/bin/node
+COPY --from=node_source /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node_source /usr/local/include/node /usr/local/include/node
+
+# Symlink npm and npx; copy yarn directly from the node image
+COPY --from=node_source /usr/local/bin/yarn /usr/local/bin/yarn
+COPY --from=node_source /usr/local/bin/yarnpkg /usr/local/bin/yarnpkg
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+ENV APP_HOME /home/loco_demo
+WORKDIR $APP_HOME
+
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
+RUN echo 'alias be="bundle exec"\nalias la="ls -al"' >> ~/.bashrc
+
+CMD ["/usr/bin/tini", "--", "./bin/dev"]


### PR DESCRIPTION
## Context

Claude Code sessions have no awareness of the project's coding conventions unless a <code>CLAUDE.md</code> file is present. We already maintain a comprehensive set of rules under <code>.windsurf/rules/</code> and workflows under <code>.windsurf/workflows/</code>, so rather than duplicating them, <code>CLAUDE.md</code> simply references each file using Claude Code's <code>@path</code> import syntax.

The <code>Dockerfile.demo.cloud</code> addresses a gap in the existing <code>Dockerfile.demo</code>: in network-restricted environments (such as Claude Code cloud sessions), <code>apt-get</code> cannot reach <code>deb.debian.org</code> or <code>nodesource.com</code>. A multi-stage build that copies Node.js directly from an official image sidesteps both blocked hosts entirely.

## Related Issues

Fixes #90

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [x] Other (please describe): Add cloud-compatible Dockerfile for network-restricted build environments

## Description

- Add <code>CLAUDE.md</code> at the repo root referencing every file under <code>.windsurf/rules/</code> and <code>.windsurf/workflows/</code>. Includes all 17 rule files currently in the repo, including several that post-date the original issue example (<code>creating_guides.md</code>, <code>generating_a_pr_description.md</code>, <code>maintaining_rules.md</code>, <code>non_code_documentation.md</code>, <code>releasing.md</code>, <code>starting_an_issue.md</code>, <code>updating_the_changelog.md</code>).
- Add <code>docs/demo/Dockerfile.demo.cloud</code>: a multi-stage Dockerfile that pulls <code>ruby:3.4.4</code> (full image, already includes <code>build-essential</code>) and copies Node.js binaries from <code>node:20-slim</code> rather than installing via <code>apt-get</code> or <code>nodesource</code>.
- Update <code>CHANGELOG.md</code> with entries for both changes under the <code>[Unreleased]</code> section, and consolidate the two duplicate <code>[Unreleased]</code> headers that had accumulated from previous PRs.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements

https://claude.ai/code/session_01GGQotYq2zM9yjhK97GAV7s