### PR TITLE
Enhance Alert component for better usage.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,7 @@
 - [ ] I have added appropriate YARD documentation (if applicable)
 - [ ] I have followed the project's documentation standards
 - [ ] I have reviewed my own code for potential improvements
+- [ ] I have updated the CHANGELOG.md file (if applicable)
 
 ## Additional Notes
 <!-- Add any additional notes, screenshots, or context about the changes -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ releases** should be considered **breaking**!
 
 - add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image gallery examples
 - add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in network-restricted environments (e.g. Claude Code cloud) where OS package repos are blocked; uses a multi-stage build to copy Node.js from `node:20-slim` instead of installing via `nodesource`
+- feat(Alert): Add auto-dismiss, clickable link, and Stimulus action features with examples
+- feat(Alert): Add AlertController to NPM package for client-side alert management
+- feat(Toast): Enhance Toast examples with closable, auto-dismiss, and clickable features
+- feat(Toast): Add Toast positions example and reset functionality
+- docs(Toast): Update documentation to warn about AlertController dependency
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,23 @@ releases** should be considered **breaking**!
 
 - add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent` ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
 - feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
+- feat(Alert): Add auto-dismiss functionality with `autoclose` and `timeout` parameters
+- feat(Alert): Add clickable link functionality with `href` and `target` parameters
+- feat(Alert): Add Stimulus action support with `action` parameter
+- feat(Alert): Add closable functionality with `closable` parameter and close button
+- feat(Alert): Add AlertController to NPM package for client-side alert management
+- feat(Configuration): Add comprehensive documentation to Configuration class
 
 ### Demo / Docs Changes
 
 - add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image gallery examples
 - add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in network-restricted environments (e.g. Claude Code cloud) where OS package repos are blocked; uses a multi-stage build to copy Node.js from `node:20-slim` instead of installing via `nodesource`
-- feat(Alert): Add auto-dismiss, clickable link, and Stimulus action features with examples
-- feat(Alert): Add AlertController to NPM package for client-side alert management
+- feat(Alert): Add closable, auto-dismissing, clickable link, and Stimulus action alert examples
+- feat(Alert): Add AlertDemoController for interactive click celebration demo
 - feat(Toast): Enhance Toast examples with closable, auto-dismiss, and clickable features
 - feat(Toast): Add Toast positions example and reset functionality
 - docs(Toast): Update documentation to warn about AlertController dependency
+- docs(Alert): Update Alert examples with improved descriptions and formatting
 
 ### Changed
 

--- a/app/components/daisy/feedback/alert_component.html.haml
+++ b/app/components/daisy/feedback/alert_component.html.haml
@@ -1,4 +1,7 @@
 = part(:component) do
+  - if closable?
+    = part(:close) do
+      = hero_icon "x-mark", css: "where:size-4"
   - # If we have an icon, assume we want to wrap the content
   - if @icon.present?
     = render_icon

--- a/app/components/daisy/feedback/alert_component.html.haml
+++ b/app/components/daisy/feedback/alert_component.html.haml
@@ -1,7 +1,4 @@
 = part(:component) do
-  - if closable?
-    = part(:close) do
-      = hero_icon "x-mark", css: "where:size-4"
   - # If we have an icon, assume we want to wrap the content
   - if @icon.present?
     = render_icon
@@ -9,3 +6,6 @@
       = content
   - else
     = content
+  - if closable?
+    = part(:close) do
+      = hero_icon "x-mark", css: "where:size-4"

--- a/app/components/daisy/feedback/alert_component.rb
+++ b/app/components/daisy/feedback/alert_component.rb
@@ -9,11 +9,21 @@
 # @part content_wrapper  [HTML] A wrapper for the main content of the alert.
 #   This allows for proper spacing and alignment with the icon.
 #
+# @part close            [Button] A close button that appears when closable is true.
+#
 # @option kws [String] :style (:default) The style of the alert.
 #   [:info, :success, :warning, :error, :default]
 # @option kws [Boolean] :soft (false) Use the soft style variant.
 # @option kws [Boolean] :outline (false) Use the outline style variant.
 # @option kws [Boolean] :dash (false) Use the dash style variant.
+# @option kws [Integer] :timeout (nil) Auto-dismiss timeout in milliseconds.
+#   If nil, uses global configuration default. If false, no auto-dismiss.
+# @option kws [Boolean] :autoclose (false) Enable auto-dismiss using timeout.
+#   Must be true for auto-dismiss to work.
+# @option kws [String] :href (nil) Converts alert to a clickable link.
+# @option kws [String] :action (nil) Stimulus action to fire on click.
+# @option kws [Boolean] :closable (false) Show close button. Set to true to enable
+#   manual dismissal.
 #
 # @loco_example Basic Alert
 #   = daisy_alert do
@@ -104,10 +114,27 @@
 #   = daisy_alert(css: "alert-error alert-dash") do
 #     This is a dash error alert.
 #
+# @loco_example Closable Alert
+#   = daisy_alert(icon: "information-circle", css: "alert-info", icon_html: { variant: :outline }) do
+#     This alert can be closed manually.
+#
+# @loco_example Auto-dismissing Alert
+#   = daisy_alert(icon: "check-circle", css: "alert-success", autoclose: true, timeout: 3000, icon_html: { variant: :outline }) do
+#     This alert will auto-dismiss in 3 seconds.
+#
+# @loco_example Clickable Link Alert
+#   = daisy_alert(icon: "information-circle", css: "alert-info", href: "/docs", icon_html: { variant: :outline }) do
+#     Click to view documentation.
+#
+# @loco_example Stimulus Action Alert
+#   = daisy_alert(icon: "exclamation-triangle", css: "alert-warning", action: "click->my-controller#handle", icon_html: { variant: :outline }) do
+#     Click to trigger custom action.
+#
 class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::IconableComponent
+  include LocoMotion::Concerns::LinkableComponent
 
-  define_parts :icon, :content_wrapper
+  define_parts :icon, :content_wrapper, :close
 
   #
   # Creates a new Alert component.
@@ -130,11 +157,23 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
   # @option kws soft     [Boolean] Use the soft style variant.
   # @option kws outline  [Boolean] Use the outline style variant.
   # @option kws dash     [Boolean] Use the dash style variant.
+  # @option kws timeout  [Integer] Auto-dismiss timeout in milliseconds.
+  #   If nil, uses global configuration default. If false, no auto-dismiss.
+  # @option kws autoclose [Boolean] Enable auto-dismiss using timeout.
+  #   Must be true for auto-dismiss to work.
+  # @option kws href     [String] Converts alert to a clickable link.
+  # @option kws action   [String] Stimulus action to fire on click.
+  # @option kws closable [Boolean] Show close button. Set to true to enable
+  #   manual dismissal.
   #
   def initialize(*args, **kws, &block)
     super
 
     @icon = config_option(:icon)
+    @timeout = config_option(:timeout)
+    @autoclose = config_option(:autoclose)
+    @action = config_option(:action)
+    @closable = config_option(:closable)
   end
 
   def default_icon_size
@@ -142,7 +181,73 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
   end
 
   def before_render
-    add_css(:component, "alert")
+    # Call super first to run concern setups (LinkableComponent)
+    super
+
+    add_css(:component, "alert where:relative")
     add_html(:component, { role: "alert" })
+
+    setup_stimulus_controller
+    setup_timeout
+    setup_action
+    setup_closable
+    setup_close_button
+    setup_closable_padding
+  end
+
+  private
+
+  def setup_stimulus_controller
+    add_stimulus_controller(:component, "loco-alert")
+  end
+
+  def setup_timeout
+    timeout_value = if @timeout == false
+      nil
+    elsif @timeout.nil?
+      LocoMotion.configuration.default_alert_timeout
+    else
+      @timeout
+    end
+
+    # Only add data-timeout if autoclose is true
+    if timeout_value && @autoclose
+      add_html(:component, { "data-timeout": timeout_value })
+    end
+  end
+
+  def setup_action
+    if @action
+      add_html(:component, { "data-action": @action })
+    end
+  end
+
+  def setup_closable
+    # Default to not closable unless explicitly set to true
+    should_be_closable = if @closable.nil?
+      false
+    else
+      @closable
+    end
+
+    @closable = should_be_closable
+  end
+
+  def closable?
+    @closable
+  end
+
+  def setup_close_button
+    return unless closable?
+
+    set_tag_name(:close, :button)
+    add_css(:close, "btn btn-link btn-xs where:absolute where:top-3 where:right-2")
+    add_html(:close, { "data-action": "click->loco-alert#close" })
+  end
+
+  def setup_closable_padding
+    return unless closable?
+
+    add_css(:component, "where:pr-10")
   end
 end

--- a/app/components/daisy/feedback/alert_component.rb
+++ b/app/components/daisy/feedback/alert_component.rb
@@ -115,7 +115,7 @@
 #     This is a dash error alert.
 #
 # @loco_example Closable Alert
-#   = daisy_alert(icon: "information-circle", css: "alert-info", icon_html: { variant: :outline }) do
+#   = daisy_alert(icon: "information-circle", css: "alert-info", closable: true, icon_html: { variant: :outline }) do
 #     This alert can be closed manually.
 #
 # @loco_example Auto-dismissing Alert
@@ -135,6 +135,10 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LinkableComponent
 
   define_parts :icon, :content_wrapper, :close
+
+  # @return [Boolean] Whether or not this alert can be closed.
+  attr_reader :closable
+  alias :closable? :closable
 
   #
   # Creates a new Alert component.
@@ -173,7 +177,7 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
     @timeout = config_option(:timeout)
     @autoclose = config_option(:autoclose)
     @action = config_option(:action)
-    @closable = config_option(:closable)
+    @closable = config_option(:closable, false)
   end
 
   def default_icon_size
@@ -181,23 +185,27 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
   end
 
   def before_render
-    # Call super first to run concern setups (LinkableComponent)
-    super
+    setup_component
 
-    add_css(:component, "alert where:relative")
+    super
+  end
+
+  private
+
+  def setup_component
+    add_css(:component, "alert")
     add_html(:component, { role: "alert" })
 
     setup_stimulus_controller
     setup_timeout
     setup_action
-    setup_closable
     setup_close_button
     setup_closable_padding
   end
 
-  private
-
   def setup_stimulus_controller
+    return unless closable? || @autoclose
+
     add_stimulus_controller(:component, "loco-alert")
   end
 
@@ -210,9 +218,10 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
       @timeout
     end
 
-    # Only add data-timeout if autoclose is true
     if timeout_value && @autoclose
-      add_html(:component, { "data-timeout": timeout_value })
+      add_html(:component, {
+        "data-loco-alert-timeout-value": timeout_value
+      })
     end
   end
 
@@ -220,21 +229,6 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
     if @action
       add_html(:component, { "data-action": @action })
     end
-  end
-
-  def setup_closable
-    # Default to not closable unless explicitly set to true
-    should_be_closable = if @closable.nil?
-      false
-    else
-      @closable
-    end
-
-    @closable = should_be_closable
-  end
-
-  def closable?
-    @closable
   end
 
   def setup_close_button
@@ -248,6 +242,6 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
   def setup_closable_padding
     return unless closable?
 
-    add_css(:component, "where:pr-10")
+    add_css(:component, "where:relative where:pr-10")
   end
 end

--- a/app/components/daisy/feedback/alert_component.rb
+++ b/app/components/daisy/feedback/alert_component.rb
@@ -235,7 +235,7 @@ class Daisy::Feedback::AlertComponent < LocoMotion::BaseComponent
     return unless closable?
 
     set_tag_name(:close, :button)
-    add_css(:close, "btn btn-link btn-xs where:absolute where:top-3 where:right-2")
+    add_css(:close, "btn btn-ghost btn-circle btn-xs where:absolute where:top-3 where:right-2")
     add_html(:close, { "data-action": "click->loco-alert#close" })
   end
 

--- a/app/components/daisy/feedback/alert_controller.js
+++ b/app/components/daisy/feedback/alert_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Alert Controller
+ *
+ * A Stimulus controller that manages alert dismissal and auto-dismissal.
+ * Handles manual close actions and automatic dismissal after a configurable timeout.
+ */
+export default class extends Controller {
+  static values = {
+    timeout: { type: Number, default: 0 }
+  }
+
+  /**
+   * Called when the controller is connected to the DOM.
+   * Sets up auto-dismiss timer if timeout is greater than 0.
+   */
+  connect() {
+    this.timeoutValue = this.element.dataset.timeout || this.timeoutValue
+
+    if (this.timeoutValue > 0) {
+      this.setupAutoDismiss()
+    }
+  }
+
+  /**
+   * Called when the controller is disconnected from the DOM.
+   * Clears the auto-dismiss timer to prevent memory leaks.
+   */
+  disconnect() {
+    if (this.dismissTimer) {
+      clearTimeout(this.dismissTimer)
+    }
+  }
+
+  /**
+   * Sets up the auto-dismiss timer based on the configured timeout.
+   */
+  setupAutoDismiss() {
+    this.dismissTimer = setTimeout(() => {
+      this.close()
+    }, this.timeoutValue)
+  }
+
+  /**
+   * Closes the alert with a smooth transition and removes it from the DOM.
+   */
+  close() {
+    // Add a class to trigger the transition
+    this.element.classList.add('where:opacity-0', 'where:transition-opacity', 'where:duration-300')
+
+    // Wait for the transition to complete before removing the element
+    setTimeout(() => {
+      this.element.remove()
+    }, 300)
+  }
+}

--- a/app/components/daisy/feedback/alert_controller.js
+++ b/app/components/daisy/feedback/alert_controller.js
@@ -4,52 +4,39 @@ import { Controller } from "@hotwired/stimulus"
  * Alert Controller
  *
  * A Stimulus controller that manages alert dismissal and auto-dismissal.
- * Handles manual close actions and automatic dismissal after a configurable timeout.
+ * Handles manual close actions and automatic dismissal after a
+ * configurable timeout.
  */
 export default class extends Controller {
   static values = {
     timeout: { type: Number, default: 0 }
   }
 
-  /**
-   * Called when the controller is connected to the DOM.
-   * Sets up auto-dismiss timer if timeout is greater than 0.
-   */
   connect() {
-    this.timeoutValue = this.element.dataset.timeout || this.timeoutValue
-
     if (this.timeoutValue > 0) {
       this.setupAutoDismiss()
     }
   }
 
-  /**
-   * Called when the controller is disconnected from the DOM.
-   * Clears the auto-dismiss timer to prevent memory leaks.
-   */
   disconnect() {
     if (this.dismissTimer) {
       clearTimeout(this.dismissTimer)
     }
   }
 
-  /**
-   * Sets up the auto-dismiss timer based on the configured timeout.
-   */
   setupAutoDismiss() {
     this.dismissTimer = setTimeout(() => {
       this.close()
     }, this.timeoutValue)
   }
 
-  /**
-   * Closes the alert with a smooth transition and removes it from the DOM.
-   */
   close() {
-    // Add a class to trigger the transition
-    this.element.classList.add('where:opacity-0', 'where:transition-opacity', 'where:duration-300')
+    this.element.classList.add(
+      'where:opacity-0',
+      'where:transition-opacity',
+      'where:duration-300'
+    )
 
-    // Wait for the transition to complete before removing the element
     setTimeout(() => {
       this.element.remove()
     }, 300)

--- a/docs/demo/app/javascript/controllers/alert_demo_controller.js
+++ b/docs/demo/app/javascript/controllers/alert_demo_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="alert-demo"
+export default class AlertDemoController extends Controller {
+  static targets = ["alert"]
+  static values = {
+    clickCount: { type: Number, default: 0 }
+  }
+
+  celebrate() {
+    // Stop at 100 clicks
+    if (this.clickCountValue >= 100) {
+      return
+    }
+
+    this.clickCountValue++
+
+    const messages = [
+      "🎉 Nice click!",
+      "✨ Keep going!",
+      "🚀 You're on fire!",
+      "🌟 Amazing!",
+      "💪 You're a clicking machine!",
+      "🎊 Party time!",
+      "🏆 Champion clicker!",
+    ]
+
+    const emojis = ["🎉", "✨", "🚀", "🌟", "💪", "🎊", "🏆", "💖", "🌈", "⭐"]
+
+    const message = messages[Math.floor(Math.random() * messages.length)]
+    const emoji = emojis[Math.floor(Math.random() * emojis.length)]
+
+    if (this.clickCountValue === 100) {
+      // Special 100 clicks celebration
+      this.alertTarget.innerHTML = `🎉🎊🎉 LEGENDARY! You reached 100 clicks! 🏆👑🎉🎊🎉`
+      this.alertTarget.classList.add('animate-pulse')
+      // Make it rainbow colored
+      this.alertTarget.style.background = 'linear-gradient(90deg, #ff0000, #ff7f00, #ffff00, #00ff00, #0000ff, #4b0082, #8f00ff)'
+      this.alertTarget.style.backgroundSize = '400% 400%'
+      this.alertTarget.style.animation = 'rainbow 3s ease infinite'
+    } else {
+      this.alertTarget.innerHTML = `${message} ${emoji} (${this.clickCountValue} clicks)`
+
+      // Add a fun animation class
+      this.alertTarget.classList.add('animate-bounce')
+      setTimeout(() => {
+        this.alertTarget.classList.remove('animate-bounce')
+      }, 500)
+    }
+  }
+}

--- a/docs/demo/app/javascript/controllers/alert_demo_controller.js
+++ b/docs/demo/app/javascript/controllers/alert_demo_controller.js
@@ -31,17 +31,14 @@ export default class AlertDemoController extends Controller {
     const emoji = emojis[Math.floor(Math.random() * emojis.length)]
 
     if (this.clickCountValue === 100) {
-      // Special 100 clicks celebration
-      this.alertTarget.innerHTML = `🎉🎊🎉 LEGENDARY! You reached 100 clicks! 🏆👑🎉🎊🎉`
+      this.alertTarget.textContent = "🎉🎊🎉 LEGENDARY! You reached 100 clicks! 🏆👑🎉🎊🎉"
       this.alertTarget.classList.add('animate-pulse')
-      // Make it rainbow colored
       this.alertTarget.style.background = 'linear-gradient(90deg, #ff0000, #ff7f00, #ffff00, #00ff00, #0000ff, #4b0082, #8f00ff)'
       this.alertTarget.style.backgroundSize = '400% 400%'
       this.alertTarget.style.animation = 'rainbow 3s ease infinite'
     } else {
-      this.alertTarget.innerHTML = `${message} ${emoji} (${this.clickCountValue} clicks)`
+      this.alertTarget.textContent = `${message} ${emoji} (${this.clickCountValue} clicks)`
 
-      // Add a fun animation class
       this.alertTarget.classList.add('animate-bounce')
       setTimeout(() => {
         this.alertTarget.classList.remove('animate-bounce')

--- a/docs/demo/app/javascript/controllers/index.js
+++ b/docs/demo/app/javascript/controllers/index.js
@@ -6,11 +6,11 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Import LocoMotion controllers
-import { CountdownController, ThemeController, CallyInputController, AlertController } from "@profoundry-us/loco_motion"
+import { AlertController, CallyInputController, CountdownController, ThemeController } from "@profoundry-us/loco_motion"
+application.register("loco-alert", AlertController)
+application.register("loco-cally-input", CallyInputController)
 application.register("loco-countdown", CountdownController)
 application.register("loco-theme", ThemeController)
-application.register("loco-cally-input", CallyInputController)
-application.register("loco-alert", AlertController)
 
 // Import demo app controllers
 
@@ -20,11 +20,14 @@ application.register("active-tab", ActiveTabController)
 import AdsController from "./ads_controller"
 application.register("ads", AdsController)
 
-import DocTitleController from "./doc_title_controller"
-application.register("doc-title", DocTitleController)
+import AlertDemoController from "./alert_demo_controller"
+application.register("alert-demo", AlertDemoController)
 
 import DocExampleController from "./doc_example_controller"
 application.register("doc-example", DocExampleController)
+
+import DocTitleController from "./doc_title_controller"
+application.register("doc-title", DocTitleController)
 
 import HighlightCodeController from "./highlight_code_controller"
 application.register("highlight-code", HighlightCodeController)
@@ -34,9 +37,6 @@ application.register("nav", NavController)
 
 import StackGapController from "./stack_gap_controller"
 application.register("stack-gap", StackGapController)
-
-import AlertDemoController from "./alert_demo_controller"
-application.register("alert-demo", AlertDemoController)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/docs/demo/app/javascript/controllers/index.js
+++ b/docs/demo/app/javascript/controllers/index.js
@@ -6,10 +6,11 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Import LocoMotion controllers
-import { CountdownController, ThemeController, CallyInputController } from "@profoundry-us/loco_motion"
+import { CountdownController, ThemeController, CallyInputController, AlertController } from "@profoundry-us/loco_motion"
 application.register("loco-countdown", CountdownController)
 application.register("loco-theme", ThemeController)
 application.register("loco-cally-input", CallyInputController)
+application.register("loco-alert", AlertController)
 
 // Import demo app controllers
 
@@ -33,6 +34,9 @@ application.register("nav", NavController)
 
 import StackGapController from "./stack_gap_controller"
 application.register("stack-gap", StackGapController)
+
+import AlertDemoController from "./alert_demo_controller"
+application.register("alert-demo", AlertDemoController)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/docs/demo/app/views/examples/daisy/feedback/alerts.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/alerts.html.haml
@@ -118,11 +118,13 @@
 = doc_example(title: "Closable Alerts", example_css: "flex-col space-y-8", allow_reset: true) do |doc|
   - doc.with_description do
     :markdown
-      Alerts can be manually closed by clicking the X button. Set `closable: true` to show the close button. Click the **Reset** button to show the alerts again after they are closed.
+      Alerts can be manually closed by clicking the X button. Set `closable:
+      true` to show the close button. Click the **Reset** button to show the
+      alerts again after they are closed.
 
   = daisy_alert(icon: "information-circle", css: "alert-info w-100", closable: true, icon_html: { variant: :outline }) do
-    This alert can be closed manually.
-    It has multiple lines of text to show the close button positioning.
+    This alert can be closed manually. It has multiple lines of text to show the
+    close button positioning.
 
   = daisy_alert(icon: "check-circle", css: "alert-success w-100", closable: true, icon_html: { variant: :outline }) do
     Success! Click the X to dismiss.
@@ -131,7 +133,9 @@
 = doc_example(title: "Auto-dismissing Alerts", example_css: "flex-col space-y-8", allow_reset: true) do |doc|
   - doc.with_description do
     :markdown
-      Alerts can auto-dismiss after a specified timeout. Set `autoclose: true` and `timeout` in milliseconds. Click the **Reset** button to show the alerts again after they dismiss.
+      Alerts can auto-dismiss after a specified timeout. Set `autoclose: true`
+      and `timeout` in milliseconds. Click the **Reset** button to show the
+      alerts again after they dismiss.
 
   = daisy_alert(icon: "check-circle", css: "alert-success w-100", autoclose: true, timeout: 3000, icon_html: { variant: :outline }) do
     This alert will auto-dismiss in 3 seconds.
@@ -143,7 +147,8 @@
 = doc_example(title: "Clickable Link Alerts", example_css: "flex-col space-y-8") do |doc|
   - doc.with_description do
     :markdown
-      Alerts can be converted to clickable links by providing an `href` parameter. Use `target` to control where the link opens.
+      Alerts can be converted to clickable links by providing an `href`
+      parameter. Use `target` to control where the link opens.
 
   = daisy_alert(icon: "star", css: "alert-info w-100", href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", target: "_blank", icon_html: { variant: :outline }) do
     Click this alert for a surprise! (opens in new tab)
@@ -155,7 +160,8 @@
 = doc_example(title: "Stimulus Action Alerts", example_css: "flex-col space-y-8") do |doc|
   - doc.with_description do
     :markdown
-      Alerts can trigger custom Stimulus actions by providing an `action` parameter.
+      Alerts can trigger custom Stimulus actions by providing an `action`
+      parameter.
 
   %div{ data: { controller: "alert-demo" } }
     = daisy_alert(icon: "sparkles", css: "alert-warning w-100 hover:cursor-pointer", action: "click->alert-demo#celebrate", html: { data: { alert_demo_target: "alert" } }, icon_html: { variant: :outline }) do
@@ -165,7 +171,9 @@
 = doc_example(title: "Custom Timeout Alerts", example_css: "flex-col space-y-8", allow_reset: true) do |doc|
   - doc.with_description do
     :markdown
-      You can customize the timeout for each alert. Set `autoclose: true` with a custom `timeout` value. Click the **Reset** button to show the alerts again after they dismiss.
+      You can customize the timeout for each alert. Set `autoclose: true` with a
+      custom `timeout` value. Click the **Reset** button to show the alerts
+      again after they dismiss.
 
   = daisy_alert(icon: "check-circle", css: "alert-success w-100", autoclose: true, timeout: 2000, icon_html: { variant: :outline }) do
     Dismisses in 2 seconds.

--- a/docs/demo/app/views/examples/daisy/feedback/alerts.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/alerts.html.haml
@@ -148,7 +148,7 @@
   = daisy_alert(icon: "star", css: "alert-info w-100", href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", target: "_blank", icon_html: { variant: :outline }) do
     Click this alert for a surprise! (opens in new tab)
 
-  = daisy_alert(icon: "check-circle", css: "alert-success w-100", href: "/api_docs", target: "_blank", icon_html: { variant: :outline }) do
+  = daisy_alert(icon: "check-circle", css: "alert-success w-100", href: "/api-docs", target: "_blank", icon_html: { variant: :outline }) do
     Click to view documentation.
 
 
@@ -158,7 +158,7 @@
       Alerts can trigger custom Stimulus actions by providing an `action` parameter.
 
   %div{ data: { controller: "alert-demo" } }
-    = daisy_alert(icon: "sparkles", css: "alert-warning w-100", action: "click->alert-demo#celebrate", html: { data: { alert_demo_target: "alert" } }, icon_html: { variant: :outline }) do
+    = daisy_alert(icon: "sparkles", css: "alert-warning w-100 hover:cursor-pointer", action: "click->alert-demo#celebrate", html: { data: { alert_demo_target: "alert" } }, icon_html: { variant: :outline }) do
       Click to celebrate!
 
 

--- a/docs/demo/app/views/examples/daisy/feedback/alerts.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/alerts.html.haml
@@ -113,3 +113,62 @@
 
   = daisy_alert(icon: "exclamation-circle", css: "alert-error alert-dash") do
     Error alert.
+
+
+= doc_example(title: "Closable Alerts", example_css: "flex-col space-y-8", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      Alerts can be manually closed by clicking the X button. Set `closable: true` to show the close button. Click the **Reset** button to show the alerts again after they are closed.
+
+  = daisy_alert(icon: "information-circle", css: "alert-info w-100", closable: true, icon_html: { variant: :outline }) do
+    This alert can be closed manually.
+    It has multiple lines of text to show the close button positioning.
+
+  = daisy_alert(icon: "check-circle", css: "alert-success w-100", closable: true, icon_html: { variant: :outline }) do
+    Success! Click the X to dismiss.
+
+
+= doc_example(title: "Auto-dismissing Alerts", example_css: "flex-col space-y-8", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      Alerts can auto-dismiss after a specified timeout. Set `autoclose: true` and `timeout` in milliseconds. Click the **Reset** button to show the alerts again after they dismiss.
+
+  = daisy_alert(icon: "check-circle", css: "alert-success w-100", autoclose: true, timeout: 3000, icon_html: { variant: :outline }) do
+    This alert will auto-dismiss in 3 seconds.
+
+  = daisy_alert(icon: "information-circle", css: "alert-info w-100", autoclose: true, timeout: 5000, icon_html: { variant: :outline }) do
+    This alert will auto-dismiss in 5 seconds.
+
+
+= doc_example(title: "Clickable Link Alerts", example_css: "flex-col space-y-8") do |doc|
+  - doc.with_description do
+    :markdown
+      Alerts can be converted to clickable links by providing an `href` parameter. Use `target` to control where the link opens.
+
+  = daisy_alert(icon: "star", css: "alert-info w-100", href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", target: "_blank", icon_html: { variant: :outline }) do
+    Click this alert for a surprise! (opens in new tab)
+
+  = daisy_alert(icon: "check-circle", css: "alert-success w-100", href: "/api_docs", target: "_blank", icon_html: { variant: :outline }) do
+    Click to view documentation.
+
+
+= doc_example(title: "Stimulus Action Alerts", example_css: "flex-col space-y-8") do |doc|
+  - doc.with_description do
+    :markdown
+      Alerts can trigger custom Stimulus actions by providing an `action` parameter.
+
+  %div{ data: { controller: "alert-demo" } }
+    = daisy_alert(icon: "sparkles", css: "alert-warning w-100", action: "click->alert-demo#celebrate", html: { data: { alert_demo_target: "alert" } }, icon_html: { variant: :outline }) do
+      Click to celebrate!
+
+
+= doc_example(title: "Custom Timeout Alerts", example_css: "flex-col space-y-8", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      You can customize the timeout for each alert. Set `autoclose: true` with a custom `timeout` value. Click the **Reset** button to show the alerts again after they dismiss.
+
+  = daisy_alert(icon: "check-circle", css: "alert-success w-100", autoclose: true, timeout: 2000, icon_html: { variant: :outline }) do
+    Dismisses in 2 seconds.
+
+  = daisy_alert(icon: "information-circle", css: "alert-info w-100", timeout: 5000, icon_html: { variant: :outline }) do
+    This alert will not auto-dismiss (autoclose is false by default).

--- a/docs/demo/app/views/examples/daisy/feedback/toasts.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/toasts.html.haml
@@ -16,7 +16,7 @@
 
     = doc_code(language: "js") do
       :plain
-        import { AlertController } from 'loco_motion'
+        import { AlertController } from '@profoundry-us/loco_motion'
 
         application.register('loco-alert', AlertController)
 
@@ -66,7 +66,7 @@
       disappear after 20 & 25 seconds. Click **Reset** to show them again.
 
   = daisy_toast(css: "z-50") do
-    = daisy_alert(icon: "check-circle", css: "alert-success text-white", href: "/api_docs", target: "_blank", autoclose: true, timeout: 20000, icon_html: { variant: :outline }) do
+    = daisy_alert(icon: "check-circle", css: "alert-success text-white", href: "/api-docs", target: "_blank", autoclose: true, timeout: 20000, icon_html: { variant: :outline }) do
       View API documentation (opens in new tab)
 
     = daisy_alert(icon: "star", css: "alert-info text-white", href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", target: "_blank", autoclose: true, timeout: 25000, icon_html: { variant: :outline }) do

--- a/docs/demo/app/views/examples/daisy/feedback/toasts.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/toasts.html.haml
@@ -2,26 +2,72 @@
   %p
     Toasts are used to show a message to the user that is not critical, but
     important. They are often used to show a message that is not part of the
-    main content flow and can be dismissed by the user.
+    main content flow and can be dismissed after a timeout or by a user.
 
-= doc_note(modifier: :todo, css: "mt-4 max-w-2xl") do
-  :markdown
-    Currently, the Toast component does **not** include any JavaScript to handle
-    showing / hiding the toast. We plan to implement a basic Stimulus
-    ToastController in the future.
+  = doc_note(modifier: :warning) do
+    :markdown
+      The Toast component relies on the Alert component's Stimulus controller
+      for auto-dismiss and manual close functionality. Ensure you have
+      registered the AlertController in your application's Stimulus controllers
+      index file.
 
-= doc_example(title: "Basic Toasts", example_css: "h-48") do |doc|
+    :markdown
+      For NPM package users, import and register the controller:
+
+    = doc_code(language: "js") do
+      :plain
+        import { AlertController } from 'loco_motion'
+
+        application.register('loco-alert', AlertController)
+
+= doc_example(title: "Basic Toasts", example_css: "h-48", allow_reset: true) do |doc|
   - doc.with_description do
     :markdown
       The Toast component is a simple wrapper that positions it's contents at
-      various spots on the page, usually in the bottom right corner.
+      various spots on the page, usually in the bottom right corner. Click the
+      **Reset** button to show the toasts again after they dismiss.
 
   :markdown
-    These toasts will appear at the bottom right of the entire page.
+    These toasts will appear at the top right of the entire page.
 
-  = daisy_toast(css: "z-10") do
-    = daisy_alert(icon: "check-circle", css: "alert-success text-white") do
+  = daisy_toast(css: "toast-top toast-end z-50") do
+    = daisy_alert(icon: "check-circle", css: "alert-success text-white", closable: true, icon_html: { variant: :outline }) do
       Yay! Something went well!
 
-    = daisy_alert(icon: "exclamation-circle", css: "alert-error text-white") do
-      Uh oh! Something went wrong...
+    = daisy_alert(icon: "exclamation-circle", css: "alert-error text-white", closable: true, icon_html: { variant: :outline }) do
+      Uh oh! Something went wrong... (click X to dismiss)
+
+
+= doc_example(title: "Toast Positions", example_css: "h-48", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      Toasts can be positioned at various locations on the page using CSS
+      modifiers. Click the **Reset** button to show the toasts again after they
+      dismiss.
+
+  :markdown
+    This toast will appear at the top left of the entire page.
+
+  = daisy_toast(css: "toast-top toast-start z-50") do
+    = daisy_alert(icon: "information-circle", css: "alert-info text-white", closable: true, icon_html: { variant: :outline }) do
+      Top-left toast
+
+
+= doc_example(title: "Clickable Toast Alerts", example_css: "h-48", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      Toasts can contain clickable link alerts that navigate to other pages or
+      resources. Click the **Reset** button to show the toasts again after they
+      dismiss.
+
+  .px-10
+    :markdown
+      These toasts will appear at the bottom right of the entire page and will
+      disappear after 20 & 25 seconds. Click **Reset** to show them again.
+
+  = daisy_toast(css: "z-50") do
+    = daisy_alert(icon: "check-circle", css: "alert-success text-white", href: "/api_docs", target: "_blank", autoclose: true, timeout: 20000, icon_html: { variant: :outline }) do
+      View API documentation (opens in new tab)
+
+    = daisy_alert(icon: "star", css: "alert-info text-white", href: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", target: "_blank", autoclose: true, timeout: 25000, icon_html: { variant: :outline }) do
+      Click for a surprise! (opens in new tab)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
+import AlertController from './app/components/daisy/feedback/alert_controller';
 import CallyInputController from './app/components/daisy/data_input/cally_input_controller';
 import CountdownController from './app/components/daisy/data_display/countdown_controller';
 import ThemeController from './app/components/daisy/actions/theme_controller';
 
 export {
+  AlertController,
   CallyInputController,
   CountdownController,
   ThemeController,

--- a/lib/loco_motion/configuration.rb
+++ b/lib/loco_motion/configuration.rb
@@ -26,10 +26,15 @@ module LocoMotion
   end
 
   #
-  # Unused for now. Was previously using to setup a base class for all
-  # LocoMotion components to inherit from.
+  # Configuration class for LocoMotion. Allows developers to customize
+  # default behavior across their application.
   #
   class Configuration
+    attr_accessor :default_alert_timeout
+
+    def initialize
+      @default_alert_timeout = 5000 # 5 seconds default
+    end
   end
 
 end

--- a/lib/loco_motion/configuration.rb
+++ b/lib/loco_motion/configuration.rb
@@ -29,7 +29,19 @@ module LocoMotion
   # Configuration class for LocoMotion. Allows developers to customize
   # default behavior across their application.
   #
+  # @example Configure LocoMotion with custom settings
+  #   LocoMotion.configure do |config|
+  #     config.default_alert_timeout = 10000
+  #   end
+  #
   class Configuration
+    #
+    # The default timeout (in milliseconds) for auto-dismissing alerts.
+    # This value is used when an Alert component has a timeout set but no
+    # explicit value is provided. The default is 5000ms (5 seconds).
+    #
+    # @return [Integer] The default timeout in milliseconds
+    #
     attr_accessor :default_alert_timeout
 
     def initialize

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "index.js",
+    "app/components/daisy/feedback/alert_controller.js",
     "app/components/daisy/data_input/cally_input_controller.js",
     "app/components/daisy/data_display/countdown_controller.js",
     "app/components/daisy/actions/theme_controller.js"

--- a/spec/components/daisy/feedback/alert_component_spec.rb
+++ b/spec/components/daisy/feedback/alert_component_spec.rb
@@ -149,12 +149,12 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
     end
 
     describe "rendering" do
-      it "includes the stimulus controller" do
-        expect(page).to have_selector("[data-controller='loco-alert']")
+      it "does not include the stimulus controller when autoclose is false" do
+        expect(page).not_to have_selector("[data-controller='loco-alert']")
       end
 
-      it "does not include data-timeout attribute when autoclose is false" do
-        expect(page).not_to have_selector("[data-timeout]")
+      it "does not include timeout value attribute when autoclose is false" do
+        expect(page).not_to have_selector("[data-loco-alert-timeout-value]")
       end
 
       it "does not show close button by default" do
@@ -175,8 +175,8 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
         expect(page).to have_selector("[data-controller='loco-alert']")
       end
 
-      it "includes the data-timeout attribute when autoclose is true" do
-        expect(page).to have_selector("[data-timeout='3000']")
+      it "includes the timeout value attribute when autoclose is true" do
+        expect(page).to have_selector("[data-loco-alert-timeout-value='3000']")
       end
 
       it "does not show close button by default" do
@@ -193,12 +193,12 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
     end
 
     describe "rendering" do
-      it "includes the stimulus controller" do
-        expect(page).to have_selector("[data-controller='loco-alert']")
+      it "does not include the stimulus controller" do
+        expect(page).not_to have_selector("[data-controller='loco-alert']")
       end
 
-      it "does not include data-timeout attribute" do
-        expect(page).not_to have_selector("[data-timeout]")
+      it "does not include timeout value attribute" do
+        expect(page).not_to have_selector("[data-loco-alert-timeout-value]")
       end
 
       it "does not show close button by default" do
@@ -215,12 +215,12 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
     end
 
     describe "rendering" do
-      it "includes the stimulus controller" do
-        expect(page).to have_selector("[data-controller='loco-alert']")
+      it "does not include the stimulus controller" do
+        expect(page).not_to have_selector("[data-controller='loco-alert']")
       end
 
-      it "does not include data-timeout attribute when autoclose is false" do
-        expect(page).not_to have_selector("[data-timeout]")
+      it "does not include timeout value attribute when autoclose is false" do
+        expect(page).not_to have_selector("[data-loco-alert-timeout-value]")
       end
 
       it "does not show close button by default" do
@@ -270,6 +270,10 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
       end
 
       describe "rendering" do
+        it "includes the stimulus controller" do
+          expect(page).to have_selector("[data-controller='loco-alert']")
+        end
+
         it "shows close button" do
           expect(page).to have_selector(".alert button")
         end
@@ -278,8 +282,8 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
           expect(page).to have_selector("button[data-action='click->loco-alert#close']")
         end
 
-        it "adds right padding to accommodate close button" do
-          expect(page).to have_selector(".alert.where\\:pr-10")
+        it "adds relative positioning and right padding" do
+          expect(page).to have_selector(".alert.where\\:relative.where\\:pr-10")
         end
       end
     end
@@ -292,11 +296,16 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
       end
 
       describe "rendering" do
+        it "does not include the stimulus controller" do
+          expect(page).not_to have_selector("[data-controller='loco-alert']")
+        end
+
         it "does not show close button" do
           expect(page).not_to have_selector(".alert button")
         end
 
-        it "does not add right padding" do
+        it "does not add relative positioning or right padding" do
+          expect(page).not_to have_selector(".alert.where\\:relative")
           expect(page).not_to have_selector(".alert.where\\:pr-10")
         end
       end

--- a/spec/components/daisy/feedback/alert_component_spec.rb
+++ b/spec/components/daisy/feedback/alert_component_spec.rb
@@ -140,4 +140,166 @@ RSpec.describe Daisy::Feedback::AlertComponent, type: :component do
       end
     end
   end
+
+  context "with timeout parameter" do
+    let(:alert) { described_class.new(timeout: 3000) }
+
+    before do
+      render_inline(alert) { "Auto-dismiss alert" }
+    end
+
+    describe "rendering" do
+      it "includes the stimulus controller" do
+        expect(page).to have_selector("[data-controller='loco-alert']")
+      end
+
+      it "does not include data-timeout attribute when autoclose is false" do
+        expect(page).not_to have_selector("[data-timeout]")
+      end
+
+      it "does not show close button by default" do
+        expect(page).not_to have_selector(".alert button")
+      end
+    end
+  end
+
+  context "with timeout and autoclose parameters" do
+    let(:alert) { described_class.new(timeout: 3000, autoclose: true) }
+
+    before do
+      render_inline(alert) { "Auto-dismiss alert" }
+    end
+
+    describe "rendering" do
+      it "includes the stimulus controller" do
+        expect(page).to have_selector("[data-controller='loco-alert']")
+      end
+
+      it "includes the data-timeout attribute when autoclose is true" do
+        expect(page).to have_selector("[data-timeout='3000']")
+      end
+
+      it "does not show close button by default" do
+        expect(page).not_to have_selector(".alert button")
+      end
+    end
+  end
+
+  context "with timeout set to false" do
+    let(:alert) { described_class.new(timeout: false) }
+
+    before do
+      render_inline(alert) { "No auto-dismiss alert" }
+    end
+
+    describe "rendering" do
+      it "includes the stimulus controller" do
+        expect(page).to have_selector("[data-controller='loco-alert']")
+      end
+
+      it "does not include data-timeout attribute" do
+        expect(page).not_to have_selector("[data-timeout]")
+      end
+
+      it "does not show close button by default" do
+        expect(page).not_to have_selector(".alert button")
+      end
+    end
+  end
+
+  context "without timeout parameter" do
+    let(:alert) { described_class.new }
+
+    before do
+      render_inline(alert) { "Default alert" }
+    end
+
+    describe "rendering" do
+      it "includes the stimulus controller" do
+        expect(page).to have_selector("[data-controller='loco-alert']")
+      end
+
+      it "does not include data-timeout attribute when autoclose is false" do
+        expect(page).not_to have_selector("[data-timeout]")
+      end
+
+      it "does not show close button by default" do
+        expect(page).not_to have_selector(".alert button")
+      end
+    end
+  end
+
+  context "with href parameter" do
+    let(:alert) { described_class.new(href: "/docs") }
+
+    before do
+      render_inline(alert) { "Clickable alert" }
+    end
+
+    describe "rendering" do
+      it "renders as an anchor tag" do
+        expect(page).to have_selector("a.alert")
+      end
+
+      it "includes the href attribute" do
+        expect(page).to have_selector("a[href='/docs']")
+      end
+    end
+  end
+
+  context "with action parameter" do
+    let(:alert) { described_class.new(action: "click->my-controller#handle") }
+
+    before do
+      render_inline(alert) { "Action alert" }
+    end
+
+    describe "rendering" do
+      it "includes the data-action attribute" do
+        expect(page).to have_selector("[data-action='click->my-controller#handle']")
+      end
+    end
+  end
+
+  context "with closable parameter" do
+    context "when closable is true" do
+      let(:alert) { described_class.new(closable: true) }
+
+      before do
+        render_inline(alert) { "Closable alert" }
+      end
+
+      describe "rendering" do
+        it "shows close button" do
+          expect(page).to have_selector(".alert button")
+        end
+
+        it "close button has correct action" do
+          expect(page).to have_selector("button[data-action='click->loco-alert#close']")
+        end
+
+        it "adds right padding to accommodate close button" do
+          expect(page).to have_selector(".alert.where\\:pr-10")
+        end
+      end
+    end
+
+    context "when closable is false" do
+      let(:alert) { described_class.new(closable: false) }
+
+      before do
+        render_inline(alert) { "Non-closable alert" }
+      end
+
+      describe "rendering" do
+        it "does not show close button" do
+          expect(page).not_to have_selector(".alert button")
+        end
+
+        it "does not add right padding" do
+          expect(page).not_to have_selector(".alert.where\\:pr-10")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
The Alert component demo needed enhancement to better showcase its full capabilities, including auto-dismiss functionality, clickable links, Stimulus actions, and closable behavior. The component was also missing client-side controller support in the NPM package, which is needed for auto-dismiss and manual close functionality.

A follow-up commit aligned the component implementation with the repo's established patterns and conventions.

## Related Issues
None

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Component update/addition
- [x] Test update/addition
- [ ] Other (please describe):

## Description
Enhanced the Alert component with new features and improved demo examples:

**Component Changes:**
- Added `autoclose` parameter to control auto-dismiss behavior (default: false).
- Added `timeout` parameter for configurable auto-dismiss timeout.
- Added `closable` parameter to enable manual close button (default: false).
- Added `href` parameter to convert alerts to clickable links (via `LinkableComponent`).
- Added `action` parameter to trigger Stimulus actions on click.
- Added close button part with proper positioning and Stimulus action.
- Stimulus controller and positioning CSS only attached when JS features are needed.

**NPM Package Changes:**
- Created `app/components/daisy/feedback/alert_controller.js` Stimulus controller.
- Added AlertController to `index.js` exports.
- Added alert_controller.js to `package.json` files array.
- Controller uses proper Stimulus values API (`data-loco-alert-timeout-value`).

**Configuration Changes:**
- Added `default_alert_timeout` configuration option (default: 5000ms).

**Demo Changes:**
- Added Closable Alerts, Auto-dismissing Alerts, Clickable Link Alerts, Stimulus Action Alerts, and Custom Timeout Alerts examples.
- Created `alert_demo_controller.js` for interactive demo.

**Pattern Alignment (follow-up commit):**
- `before_render` ordering: setup before `super` (matches `ButtonComponent`/`BadgeComponent`).
- `closable?` made public via `attr_reader` + `alias` (matches `ModalComponent`).
- Simplified `closable` initialization with `config_option(:closable, false)`.
- Stimulus controller only attached when `closable?` or `@autoclose` is true.
- `where:relative` CSS only added when closable.
- Close button moved after content in HAML for proper keyboard tab order.
- Demo controller uses `textContent` instead of `innerHTML`.

## Checklist
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements

Link to Devin session: https://app.devin.ai/sessions/783cd2ba699744e2a54d3fe21867d535
Requested by: @topherfangio