### PR TITLE
Add labelable to radio checkbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+## Browser Automation
+
+Use `chrome-devtools-mcp` for web automation.
+
+### Workflow
+
+1. Navigate to the page
+2. Get an outline of the page
+3. Interact however appropriate
+4. Make any changes to the code
+5. Refresh the page
+6. Test that the new code actually works

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,36 @@
 ## Browser Automation
 
-Use `chrome-devtools-mcp` for web automation.
+When working with web automation tasks, use the chrome-devtools-mcp server for browser control. This provides direct access to Chrome DevTools Protocol for reliable page interaction.
+
+### Tools Available
+
+- `mcp1_navigate_page` - Navigate to URLs, go back/forward, or reload
+- `mcp1_take_snapshot` - Get an accessibility tree snapshot of the page (preferred over screenshots)
+- `mcp1_click` - Click on elements by uid
+- `mcp1_fill` - Fill in input fields
+- `mcp1_fill_form` - Fill multiple form elements at once (preferred over multiple fill calls)
+- `mcp1_press_key` - Press keyboard shortcuts
+- `mcp1_evaluate_script` - Run JavaScript in the page context
+- `mcp1_take_screenshot` - Take screenshots (use only for visual verification, not for interaction)
+- `mcp1_wait_for` - Wait for text to appear on the page
 
 ### Workflow
 
-1. Navigate to the page
-2. Get an outline of the page
-3. Interact however appropriate
-4. Make any changes to the code
-5. Refresh the page
-6. Test that the new code actually works
+When automating browser interactions:
+
+1. **Navigate to the page** using `mcp1_navigate_page`
+2. **Get an outline of the page** using `mcp1_take_snapshot` to understand the structure
+3. **Identify elements** by their uid from the snapshot
+4. **Interact however appropriate** using click, fill, or other interaction tools
+5. **Make any changes to the code** based on observations
+6. **Refresh the page** and take a new snapshot to verify changes
+7. **Test that the new code actually works** by interacting with the modified elements
+
+### Best Practices
+
+- Always take a snapshot before interacting to understand the page structure
+- Use `mcp1_take_snapshot` instead of `mcp1_take_screenshot` for element identification
+- Use `mcp1_fill_form` for multiple form fields instead of individual `mcp1_fill` calls
+- Verify changes by refreshing and taking a new snapshot
+- Use `mcp1_wait_for` when waiting for dynamic content to load
+- Use `mcp1_evaluate_script` for complex interactions that can't be done with standard tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ releases** should be considered **breaking**!
 
 ### Components Changes
 
+- feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks
+- feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern
+- feat(Checkbox): Add label examples for start/end labels and custom content blocks
+- feat(Join): Add automatic `join-item` CSS class injection for items slot using `BasicComponent.build(css: "join-item")`
+- feat(Join): Add `buttons` slot using `ButtonComponent.build(css: "join-item")` for automatic CSS class injection
+- feat(Join): Add `radios` slot using `RadioButtonComponent.build(skip_styling: true, css: "join-item btn")` for automatic CSS class injection
+- feat(Join): Update call method to handle items, buttons, radios, or direct content
+- feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
+- feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
 - fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES` constant so `diff-item-1` / `diff-item-2` are detected as string literals by Tailwind v4's Ruby extractor ([Fixes #82](https://github.com/profoundry-us/loco_motion/issues/82))
 - add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent` ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
 - feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
@@ -28,6 +37,9 @@ releases** should be considered **breaking**!
 
 ### Demo / Docs Changes
 
+- feat(Join): Update join examples to use `with_button` slot instead of `with_item` for buttons
+- feat(Join): Add expansive direct content example with input, select, and indicator components
+- feat(RadioButton): Add radio buttons with labels examples to demo
 - add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image gallery examples
 - add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in network-restricted environments (e.g. Claude Code cloud) where OS package repos are blocked; uses a multi-stage build to copy Node.js from `node:20-slim` instead of installing via `nodesource`
 - add(Navbar): Add "Custom Content Navbar" example demonstrating block-based custom content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,11 @@ releases** should be considered **breaking**!
 ### Components Changes
 
 - feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks
-- feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern
 - feat(Checkbox): Add label examples for start/end labels and custom content blocks
 - feat(Join): Add automatic `join-item` CSS class injection for items slot using `BasicComponent.build(css: "join-item")`
 - feat(Join): Add `buttons` slot using `ButtonComponent.build(css: "join-item")` for automatic CSS class injection
 - feat(Join): Add `radios` slot using `RadioButtonComponent.build(skip_styling: true, css: "join-item btn")` for automatic CSS class injection
 - feat(Join): Update call method to handle items, buttons, radios, or direct content
-- feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
-- feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
 - fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES` constant so `diff-item-1` / `diff-item-2` are detected as string literals by Tailwind v4's Ruby extractor ([Fixes #82](https://github.com/profoundry-us/loco_motion/issues/82))
 - add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent` ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
 - feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
@@ -34,6 +31,12 @@ releases** should be considered **breaking**!
 - feat(Alert): Add closable functionality with `closable` parameter and close button
 - feat(Alert): Add AlertController to NPM package for client-side alert management
 - feat(Configuration): Add comprehensive documentation to Configuration class
+
+### General Changes
+
+- feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
+- feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
+- feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern
 
 ### Demo / Docs Changes
 

--- a/app/components/daisy/data_input/checkbox_component.rb
+++ b/app/components/daisy/data_input/checkbox_component.rb
@@ -26,8 +26,21 @@
 # @loco_example Disabled Checkbox
 #   = daisy_checkbox(name: "accept", id: "accept", disabled: true)
 #
+# @loco_example With Start Label
+#   = daisy_checkbox(name: "accept", id: "accept", start: "Accept:")
+#
 # @loco_example With End Label (common for checkboxes)
 #   = daisy_checkbox(name: "terms", id: "terms", end: "I agree to the terms and conditions")
+#
+# @loco_example With Custom Start Content
+#   = daisy_checkbox(name: "accept", id: "accept") do |checkbox|
+#     - checkbox.with_start do
+#       %span.text-primary Accept:
+#
+# @loco_example With Custom End Content
+#   = daisy_checkbox(name: "terms", id: "terms") do |checkbox|
+#     - checkbox.with_end do
+#       %span.text-secondary I agree to the terms
 #
 class Daisy::DataInput::CheckboxComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LabelableComponent

--- a/app/components/daisy/data_input/radio_button_component.html.haml
+++ b/app/components/daisy/data_input/radio_button_component.html.haml
@@ -1,0 +1,20 @@
+- if has_any_label?
+  = part(:label_wrapper) do
+    - if has_start_label?
+      - if start?
+        = start
+      - else
+        = part(:start) do
+          = @start
+
+    = part(:component)
+
+    - if has_end_label?
+      - if end?
+        = self.send(:end)
+      - else
+        = part(:end) do
+          = @end
+
+- else
+  = part(:component)

--- a/app/components/daisy/data_input/radio_button_component.rb
+++ b/app/components/daisy/data_input/radio_button_component.rb
@@ -5,6 +5,16 @@
 # It can be used standalone or with a form builder, and is ideal for creating
 # option groups where users must select exactly one choice.
 #
+# @part label_wrapper The wrapper element for labels (when using
+#   start/end/floating labels).
+# @part start The element that contains the start label (appears before the
+#   radio button).
+# @part end The element that contains the end label (appears after the radio
+#   button).
+#
+# @slot start Custom content for the start label.
+# @slot end Custom content for the end label.
+#
 # @loco_example Basic Usage
 #   = daisy_radio(name: "option", id: "option1", value: "1")
 #
@@ -14,7 +24,27 @@
 # @loco_example Disabled Radio Button
 #   = daisy_radio(name: "option", id: "option3", value: "3", disabled: true)
 #
+# @loco_example With Start Label
+#   = daisy_radio(name: "option", id: "option1", value: "1", start: "Option:")
+#
+# @loco_example With End Label (common for radio buttons)
+#   = daisy_radio(name: "option", id: "option1", value: "1", end: "Option 1")
+#
+# @loco_example With Custom Start Content
+#   = daisy_radio(name: "option", id: "option1", value: "1") do |radio|
+#     - radio.with_start do
+#       %span.text-primary Option:
+#
+# @loco_example With Custom End Content
+#   = daisy_radio(name: "option", id: "option1", value: "1") do |radio|
+#     - radio.with_end do
+#       %span.text-secondary Option 1
+#
 class Daisy::DataInput::RadioButtonComponent < LocoMotion::BaseComponent
+  include LocoMotion::Concerns::LabelableComponent
+
+  set_component_name :radio
+
   attr_reader :name, :id, :value, :checked, :disabled, :required
 
   #
@@ -52,7 +82,14 @@ class Daisy::DataInput::RadioButtonComponent < LocoMotion::BaseComponent
   # Calls the {setup_component} method before rendering the component.
   #
   def before_render
+    super
+
+    setup_labels
     setup_component
+  end
+
+  def setup_labels
+    add_css(:label_wrapper, "label") if has_any_label?
   end
 
   #
@@ -78,10 +115,4 @@ class Daisy::DataInput::RadioButtonComponent < LocoMotion::BaseComponent
     })
   end
 
-  #
-  # Renders the component inline with no additional whitespace.
-  #
-  def call
-    part(:component)
-  end
 end

--- a/app/components/daisy/layout/join_component.rb
+++ b/app/components/daisy/layout/join_component.rb
@@ -12,10 +12,19 @@
 # @slot item+ [LocoMotion::BaseComponent] The elements to be joined together.
 #   The `join-item` CSS class is added automatically.
 #
+# @slot button+ [Daisy::Actions::ButtonComponent] Buttons to be joined together.
+#   The `join-item` CSS class is added automatically.
+#
 # @slot radio+ [Daisy::DataInput::RadioButtonComponent] Radio buttons to be joined
 #   together. Each radio will have the `skip_styling` option set to true to prevent
 #   the automatic `radio` class from being added, and the `join-item` and `btn`
 #   classes are added automatically.
+#
+# @loco_example Basic Button Group (with with_button)
+#   = daisy_join do |join|
+#     - join.with_button(title: "Previous")
+#     - join.with_button(title: "Current", css: "btn-active")
+#     - join.with_button(title: "Next")
 #
 # @loco_example Basic Button Group (with with_item)
 #   = daisy_join do |join|
@@ -58,6 +67,7 @@
 #
 class Daisy::Layout::JoinComponent < LocoMotion::BaseComponent
   renders_many :items, LocoMotion::BasicComponent.build(css: "join-item")
+  renders_many :buttons, Daisy::Actions::ButtonComponent.build(css: "join-item")
   renders_many :radios, Daisy::DataInput::RadioButtonComponent.build(skip_styling: true, css: "join-item btn")
 
   #
@@ -83,13 +93,17 @@ class Daisy::Layout::JoinComponent < LocoMotion::BaseComponent
   end
 
   #
-  # Renders all joined items or radios in sequence, or renders content if neither are provided.
+  # Renders all joined items, buttons, or radios in sequence, or renders content if none are provided.
   #
   def call
     part(:component) do
       if items?
         items.each do |item|
           concat(item)
+        end
+      elsif buttons?
+        buttons.each do |button|
+          concat(button)
         end
       elsif radios?
         radios.each do |radio|

--- a/app/components/daisy/layout/join_component.rb
+++ b/app/components/daisy/layout/join_component.rb
@@ -6,50 +6,59 @@
 # - Segmented navigation controls.
 # - Pagination controls.
 #
-# Note: Each joined item must include the `join-item` CSS class manually, as
-# automatic application could cause rendering issues in complex scenarios.
+# Items can be added using the `with_item` slot (which automatically adds the
+# `join-item` CSS class) or the `content` method (where you must add the class manually).
 #
 # @slot item+ [LocoMotion::BaseComponent] The elements to be joined together.
-#   Each item should include the `join-item` CSS class.
+#   The `join-item` CSS class is added automatically.
 #
-# @loco_example Basic Button Group
+# @slot radio+ [Daisy::DataInput::RadioButtonComponent] Radio buttons to be joined
+#   together. Each radio will have the `skip_styling` option set to true to prevent
+#   the automatic `radio` class from being added, and the `join-item` and `btn`
+#   classes are added automatically.
+#
+# @loco_example Basic Button Group (with with_item)
 #   = daisy_join do |join|
 #     - join.with_item do
-#       = daisy_button(title: "Previous",
-#         css: "join-item")
+#       = daisy_button(title: "Previous")
 #     - join.with_item do
-#       = daisy_button(title: "Current",
-#         css: "join-item btn-active")
+#       = daisy_button(title: "Current", css: "btn-active")
 #     - join.with_item do
-#       = daisy_button(title: "Next",
-#         css: "join-item")
+#       = daisy_button(title: "Next")
+#
+# @loco_example Direct Content (without with_item)
+#   = daisy_join do
+#     = daisy_button(title: "Previous", css: "join-item")
+#     = daisy_button(title: "Current", css: "join-item btn-active")
+#     = daisy_button(title: "Next", css: "join-item")
+#
+# @loco_example Radio Buttons (with with_radio)
+#   = daisy_join do |join|
+#     - join.with_radio(name: "options", value: "1")
+#     - join.with_radio(name: "options", value: "2")
+#     - join.with_radio(name: "options", value: "3")
 #
 # @loco_example Icon Button Group
 #   = daisy_join do |join|
 #     - join.with_item do
-#       = daisy_button(icon: "chevron-left",
-#         css: "join-item")
+#       = daisy_button(icon: "chevron-left")
 #     - join.with_item do
-#       = daisy_button(icon: "home",
-#         css: "join-item")
+#       = daisy_button(icon: "home")
 #     - join.with_item do
-#       = daisy_button(icon: "chevron-right",
-#         css: "join-item")
+#       = daisy_button(icon: "chevron-right")
 #
 # @loco_example Vertical Join
 #   = daisy_join(css: "join-vertical") do |join|
 #     - join.with_item do
-#       = daisy_button(title: "Menu",
-#         css: "w-full join-item")
+#       = daisy_button(title: "Menu", css: "w-full")
 #     - join.with_item do
-#       = daisy_button(title: "Settings",
-#         css: "w-full join-item")
+#       = daisy_button(title: "Settings", css: "w-full")
 #     - join.with_item do
-#       = daisy_button(title: "Account",
-#         css: "w-full join-item")
+#       = daisy_button(title: "Account", css: "w-full")
 #
 class Daisy::Layout::JoinComponent < LocoMotion::BaseComponent
-  renders_many :items
+  renders_many :items, LocoMotion::BasicComponent.build(css: "join-item")
+  renders_many :radios, Daisy::DataInput::RadioButtonComponent.build(skip_styling: true, css: "join-item btn")
 
   #
   # Creates a new Join component.
@@ -74,12 +83,20 @@ class Daisy::Layout::JoinComponent < LocoMotion::BaseComponent
   end
 
   #
-  # Renders all joined items in sequence.
+  # Renders all joined items or radios in sequence, or renders content if neither are provided.
   #
   def call
     part(:component) do
-      items.each do |item|
-        concat(item)
+      if items?
+        items.each do |item|
+          concat(item)
+        end
+      elsif radios?
+        radios.each do |radio|
+          concat(radio)
+        end
+      else
+        content
       end
     end
   end

--- a/docs/demo/app/views/examples/daisy/data_input/radio_buttons.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/radio_buttons.html.haml
@@ -91,7 +91,7 @@
         The `with_radio` slot automatically skips the `radio` class and adds the
         `join-item` and `btn` classes for a button-style appearance.
 
-  = daisy_join(css: "") do |join|
+  = daisy_join do |join|
     - join.with_radio(name: "join_options", id: "join_radio1", value: "1", html: { aria: { label: "Radio 1" } })
     - join.with_radio(name: "join_options", id: "join_radio2", value: "2", html: { aria: { label: "Radio 2" } })
     - join.with_radio(name: "join_options", id: "join_radio3", value: "3", html: { aria: { label: "Radio 3" } })

--- a/docs/demo/app/views/examples/daisy/data_input/radio_buttons.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/radio_buttons.html.haml
@@ -25,6 +25,41 @@
       Option 3
 
 
+= doc_example(title: "Radio Buttons with Labels") do |doc|
+  - doc.with_description do
+    :markdown
+      Radio buttons can use the `start` and `end` label options for inline labeling,
+      or custom blocks for more complex label content.
+
+    = doc_note(css: "mb-8") do
+      :markdown
+        While the
+        <a href="#{doc_url("LocoMotion/Concerns/LabelableComponent")}" target="_blank">LabelableComponent</a>
+        Concern does implement a `floating_label` attribute, it is not relevant
+        for radio buttons and is not implemented.
+
+  .my-2.flex.flex-col.gap-4
+    = daisy_radio(name: "radio_end", id: "radio_end", value: "1", checked: true, end: "Radio using end wrapper")
+
+    = daisy_radio(name: "radio_start", id: "radio_start", value: "2", checked: true, start: "Radio using start wrapper")
+
+    = daisy_radio(name: "radio_end_block", id: "radio_end_block", value: "3", checked: true) do |radio|
+      - radio.with_end do
+        :markdown
+          Radio using `end` block
+
+    = daisy_radio(name: "radio_both_labels", id: "radio_both_labels", value: "4", checked: true) do |radio|
+      - radio.with_start(css: "flex flex-row items-center") do
+        Using
+        = daisy_badge(css: "mx-1 badge-secondary badge-sm") do
+          start
+      - radio.with_end(css: "flex flex-row items-center") do
+        and
+        = daisy_badge(css: "mx-1 badge-secondary badge-sm") do
+          end
+        blocks
+
+
 = doc_example(title: "Radio Buttons with Colors") do |doc|
   - doc.with_description do
     :markdown
@@ -42,6 +77,24 @@
     = daisy_label(for: "radio6") do
       = daisy_radio(name: "radio_group2", id: "radio6", value: "3", css: "radio-accent")
       Accent Radio Button
+
+
+= doc_example(title: "Join Radio Buttons with Button Style") do |doc|
+  - doc.with_description do
+    :markdown
+      Radio buttons can be grouped together using the `join` component with the
+      `with_radio` slot. This creates a segmented control where the radio buttons
+      appear as a single connected group of buttons.
+
+    = doc_note(css: "mb-8") do
+      :markdown
+        The `with_radio` slot automatically skips the `radio` class and adds the
+        `join-item` and `btn` classes for a button-style appearance.
+
+  = daisy_join(css: "") do |join|
+    - join.with_radio(name: "join_options", id: "join_radio1", value: "1", html: { aria: { label: "Radio 1" } })
+    - join.with_radio(name: "join_options", id: "join_radio2", value: "2", html: { aria: { label: "Radio 2" } })
+    - join.with_radio(name: "join_options", id: "join_radio3", value: "3", html: { aria: { label: "Radio 3" } })
 
 
 = doc_example(title: "Radio Button States") do |doc|

--- a/docs/demo/app/views/examples/daisy/layout/joins.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/joins.html.haml
@@ -13,25 +13,25 @@
 
     = doc_note(css: "mb-8") do
       :markdown
-        You **must** manually add the `.join-item` CSS class to the items you
-        want to be joined since this could be complicated to do automatically in
-        many use-cases and would almost certainly cause rendering issues.
+        When using `with_item`, the `.join-item` CSS class is added
+        automatically. When using the `content` method, you must manually add
+        the class.
 
   = daisy_join do |join|
     - join.with_item do
-      = daisy_button(title: "Start", css: "join-item")
+      = daisy_button(title: "Start")
     - join.with_item do
-      = daisy_button(title: "Center", css: "join-item")
+      = daisy_button(title: "Center")
     - join.with_item do
-      = daisy_button(title: "End", css: "join-item")
+      = daisy_button(title: "End")
 
   = daisy_join do |join|
     - join.with_item do
-      = daisy_button(icon: "bars-3-bottom-left", css: "join-item")
+      = daisy_button(icon: "bars-3-bottom-left")
     - join.with_item do
-      = daisy_button(icon: "bars-3", css: "join-item")
+      = daisy_button(icon: "bars-3")
     - join.with_item do
-      = daisy_button(icon: "bars-3-bottom-right", css: "join-item")
+      = daisy_button(icon: "bars-3-bottom-right")
 
 
 = doc_example(title: "Vertical Joins") do |doc|
@@ -41,8 +41,20 @@
 
   = daisy_join(css: "join-vertical min-w-32") do |join|
     - join.with_item do
-      = daisy_button(title: "Top", css: "w-full join-item")
+      = daisy_button(title: "Top", css: "w-full")
     - join.with_item do
-      = daisy_button(title: "Middle", css: "w-full join-item btn-primary")
+      = daisy_button(title: "Middle", css: "w-full btn-primary")
     - join.with_item do
-      = daisy_button(title: "Bottom", css: "w-full join-item")
+      = daisy_button(title: "Bottom", css: "w-full")
+
+
+= doc_example(title: "Direct Content (without with_item)") do |doc|
+  - doc.with_description do
+    %p
+      When using the `content` method instead of `with_item`, you must manually
+      add the `.join-item` CSS class to each element.
+
+  = daisy_join do
+    = daisy_button(title: "Start", css: "join-item")
+    = daisy_button(title: "Center", css: "join-item")
+    = daisy_button(title: "End", css: "join-item")

--- a/docs/demo/app/views/examples/daisy/layout/joins.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/joins.html.haml
@@ -13,25 +13,19 @@
 
     = doc_note(css: "mb-8") do
       :markdown
-        When using `with_item`, the `.join-item` CSS class is added
+        When using `with_button`, the `.join-item` CSS class is added
         automatically. When using the `content` method, you must manually add
         the class.
 
   = daisy_join do |join|
-    - join.with_item do
-      = daisy_button(title: "Start")
-    - join.with_item do
-      = daisy_button(title: "Center")
-    - join.with_item do
-      = daisy_button(title: "End")
+    - join.with_button(title: "Start")
+    - join.with_button(title: "Center")
+    - join.with_button(title: "End")
 
   = daisy_join do |join|
-    - join.with_item do
-      = daisy_button(icon: "bars-3-bottom-left")
-    - join.with_item do
-      = daisy_button(icon: "bars-3")
-    - join.with_item do
-      = daisy_button(icon: "bars-3-bottom-right")
+    - join.with_button(icon: "bars-3-bottom-left")
+    - join.with_button(icon: "bars-3")
+    - join.with_button(icon: "bars-3-bottom-right")
 
 
 = doc_example(title: "Vertical Joins") do |doc|
@@ -40,21 +34,26 @@
       You can also join elements vertically.
 
   = daisy_join(css: "join-vertical min-w-32") do |join|
-    - join.with_item do
-      = daisy_button(title: "Top", css: "w-full")
-    - join.with_item do
-      = daisy_button(title: "Middle", css: "w-full btn-primary")
-    - join.with_item do
-      = daisy_button(title: "Bottom", css: "w-full")
+    - join.with_button(title: "Top", css: "w-full")
+    - join.with_button(title: "Middle", css: "w-full btn-primary")
+    - join.with_button(title: "Bottom", css: "w-full")
 
 
 = doc_example(title: "Direct Content (without with_item)") do |doc|
   - doc.with_description do
     %p
-      When using the `content` method instead of `with_item`, you must manually
-      add the `.join-item` CSS class to each element.
+      When using the `content` method instead of `with_item` or `with_button`,
+      you must manually add the `.join-item` CSS class to each element. This
+      allows you to join different types of components together.
 
   = daisy_join do
-    = daisy_button(title: "Start", css: "join-item")
-    = daisy_button(title: "Center", css: "join-item")
-    = daisy_button(title: "End", css: "join-item")
+    = daisy_input(placeholder: "Search", css: "join-item")
+    = daisy_select(css: "join-item") do
+      %option(disabled selected) Filter
+      %option Sci-fi
+      %option Drama
+      %option Action
+    = daisy_indicator do |indicator|
+      - indicator.with_item do
+        = daisy_badge(title: "new", css: "badge-secondary")
+      = daisy_button(title: "Search", css: "join-item")

--- a/lib/loco_motion/base_component.rb
+++ b/lib/loco_motion/base_component.rb
@@ -189,15 +189,33 @@ class LocoMotion::BaseComponent < ViewComponent::Base
   # define a new class.
   #
   def self.build(*build_args, **build_kws, &build_block)
-    klass = Class.new(self)
+    # Create a named subclass instead of anonymous class to help ViewComponent
+    # find the component properly
+    build_counter = @build_counter ||= 0
+    @build_counter += 1
+    klass_name = "#{name}__Build#{build_counter}"
 
-    # Unless already defined, delegate the name method to the superclass so
-    # ViewComponent can find the sidecar partials and render them when no call
-    # method is defined.
-    unless klass.method_defined?(:name)
+    klass = Class.new(self) do
+      # Define the class name method to return the original component name
+      define_singleton_method(:name) do
+        klass_name
+      end
+    end
+
+    # Store the original superclass name for template lookup
+    superclass_name = name
+    superclass_component_name = @component_name if instance_variable_defined?(:@component_name)
+
+    # Set component_name directly on the class to avoid nil errors
+    if superclass_component_name
+      klass.instance_variable_set(:@component_name, superclass_component_name)
+    end
+
+    # Delegate sidecar_files to the superclass to avoid issues with anonymous classes
+    unless klass.method_defined?(:sidecar_files)
       klass.instance_eval do
-        def name
-          superclass.name
+        def sidecar_files(*args)
+          superclass.sidecar_files(*args)
         end
       end
     end
@@ -208,12 +226,20 @@ class LocoMotion::BaseComponent < ViewComponent::Base
 
       define_method(:initialize) do |*instance_args, **instance_kws, &instance_block|
         if original_initialize
-          original_initialize.bind(self).call
+          original_initialize.bind(self).call(*instance_args, **instance_kws, &instance_block)
         else
           super(*instance_args, **instance_kws, &instance_block)
         end
 
-        @config.smart_merge!(**build_kws)
+        # Merge build_kws into config after initialize (original behavior)
+        @config.smart_merge!(**build_kws) if instance_variable_defined?(:@config)
+
+        # Update instance variables for build_kws that correspond to instance variables
+        # This ensures options like skip_styling are available during setup_component
+        build_kws.each do |key, value|
+          instance_var = "@#{key}"
+          instance_variable_set(instance_var, value) if instance_variable_defined?(instance_var)
+        end
       end
     end
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "agent-browser": {
+      "source": "vercel-labs/agent-browser",
+      "sourceType": "github",
+      "skillPath": "skills/agent-browser/SKILL.md",
+      "computedHash": "228f87d57035100d9dc6efcfc05aafd4b6e3962adacaa04b8217ab2fadb15dc8"
+    }
+  }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,5 @@
 {
   "version": 1,
   "skills": {
-    "agent-browser": {
-      "source": "vercel-labs/agent-browser",
-      "sourceType": "github",
-      "skillPath": "skills/agent-browser/SKILL.md",
-      "computedHash": "228f87d57035100d9dc6efcfc05aafd4b6e3962adacaa04b8217ab2fadb15dc8"
-    }
   }
 }

--- a/spec/components/daisy/data_input/radio_button_component_spec.rb
+++ b/spec/components/daisy/data_input/radio_button_component_spec.rb
@@ -42,4 +42,56 @@ RSpec.describe Daisy::DataInput::RadioButtonComponent, type: :component do
 
     expect(page).to have_css("input[type='radio'][id='custom-id']")
   end
+
+  it "renders with a string start label" do
+    render_inline(described_class.new(name: "option", value: "1", start: "Option:"))
+
+    expect(page).to have_css("label")
+    expect(page).to have_css("span", text: "Option:")
+  end
+
+  it "renders with a string end label" do
+    render_inline(described_class.new(name: "option", value: "1", end: "Option 1"))
+
+    expect(page).to have_css("label")
+    expect(page).to have_css("span", text: "Option 1")
+  end
+
+  it "renders with content in the start block" do
+    render_inline(described_class.new(name: "option", value: "1")) do |component|
+      component.with_start { "Start content" }
+    end
+
+    expect(page).to have_css("label")
+    expect(page).to have_text("Start content")
+  end
+
+  it "renders with content in the end block" do
+    render_inline(described_class.new(name: "option", value: "1")) do |component|
+      component.with_end { "End content" }
+    end
+
+    expect(page).to have_css("label")
+    expect(page).to have_text("End content")
+  end
+
+  it "properly adds CSS classes when using labels" do
+    render_inline(described_class.new(name: "option", value: "1", end: "Option 1"))
+
+    expect(page).to have_css("label")
+    expect(page).to have_css("input[type='radio']")
+  end
+
+  it "adds 'label' CSS class to label_wrapper when using labels" do
+    render_inline(described_class.new(name: "option", value: "1", end: "Option 1"))
+
+    expect(page).to have_css("label.label")
+  end
+
+  it "does not add 'label' CSS class when no labels are used" do
+    render_inline(described_class.new(name: "option", value: "1"))
+
+    expect(page).not_to have_css("label.label")
+    expect(page).not_to have_css("label")
+  end
 end

--- a/spec/components/daisy/layout/join_component_spec.rb
+++ b/spec/components/daisy/layout/join_component_spec.rb
@@ -144,4 +144,34 @@ RSpec.describe Daisy::Layout::JoinComponent, type: :component do
       end
     end
   end
+
+  context "with buttons (with with_button)" do
+    let(:join) { described_class.new }
+
+    before do
+      render_inline(join) do |j|
+        j.with_button(title: "Previous")
+        j.with_button(title: "Current", css: "btn-active")
+        j.with_button(title: "Next")
+      end
+    end
+
+    describe "rendering" do
+      it "has the join class" do
+        expect(page).to have_selector(".join")
+      end
+
+      it "renders buttons" do
+        expect(page).to have_selector("button.btn", count: 3)
+      end
+
+      it "automatically adds join-item class to buttons" do
+        expect(page).to have_selector("button.join-item", count: 3)
+      end
+
+      it "preserves additional CSS classes" do
+        expect(page).to have_selector("button.btn-active")
+      end
+    end
+  end
 end

--- a/spec/components/daisy/layout/join_component_spec.rb
+++ b/spec/components/daisy/layout/join_component_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Daisy::Layout::JoinComponent, type: :component do
         expect(page).to have_text("Item 2")
         expect(page).to have_text("Item 3")
       end
+
+      it "automatically adds join-item class to items" do
+        expect(page).to have_selector(".join-item", count: 3)
+      end
     end
   end
 
@@ -44,9 +48,9 @@ RSpec.describe Daisy::Layout::JoinComponent, type: :component do
 
     before do
       render_inline(join) do |j|
-        j.with_item(css: "join-item") { "Top" }
-        j.with_item(css: "join-item") { "Middle" }
-        j.with_item(css: "join-item") { "Bottom" }
+        j.with_item { "Top" }
+        j.with_item { "Middle" }
+        j.with_item { "Bottom" }
       end
     end
 
@@ -66,13 +70,13 @@ RSpec.describe Daisy::Layout::JoinComponent, type: :component do
     end
   end
 
-  context "with join items" do
+  context "with custom CSS classes" do
     let(:join) { described_class.new }
 
     before do
       render_inline(join) do |j|
-        j.with_item(css: "join-item btn-primary") { "Primary" }
-        j.with_item(css: "join-item btn-secondary") { "Secondary" }
+        j.with_item(css: "btn-primary") { "Primary" }
+        j.with_item(css: "btn-secondary") { "Secondary" }
       end
     end
 
@@ -85,6 +89,58 @@ RSpec.describe Daisy::Layout::JoinComponent, type: :component do
       it "renders the content" do
         expect(page).to have_text("Primary")
         expect(page).to have_text("Secondary")
+      end
+    end
+  end
+
+  context "with direct content (without with_item)" do
+    let(:join) { described_class.new }
+
+    before do
+      render_inline(join) do
+        "Direct content 1 Direct content 2 Direct content 3"
+      end
+    end
+
+    describe "rendering" do
+      it "has the join class" do
+        expect(page).to have_selector(".join")
+      end
+
+      it "renders the direct content" do
+        expect(page).to have_text("Direct content 1")
+        expect(page).to have_text("Direct content 2")
+        expect(page).to have_text("Direct content 3")
+      end
+    end
+  end
+
+  context "with radio buttons (with with_radio)" do
+    let(:join) { described_class.new }
+
+    before do
+      render_inline(join) do |j|
+        j.with_radio(name: "options", value: "1")
+        j.with_radio(name: "options", value: "2")
+        j.with_radio(name: "options", value: "3")
+      end
+    end
+
+    describe "rendering" do
+      it "has the join class" do
+        expect(page).to have_selector(".join")
+      end
+
+      it "renders radio inputs" do
+        expect(page).to have_selector("input[type='radio']", count: 3)
+      end
+
+      it "does not add radio class (skip_styling)" do
+        expect(page).not_to have_selector("input.radio")
+      end
+
+      it "automatically adds join-item and btn classes" do
+        expect(page).to have_selector("input.join-item.btn", count: 3)
       end
     end
   end

--- a/spec/lib/loco_motion/base_component_spec.rb
+++ b/spec/lib/loco_motion/base_component_spec.rb
@@ -187,4 +187,95 @@ RSpec.describe LocoMotion::BaseComponent, type: :component do
     end
   end
 
+  context ".build method" do
+    class BuildableComponent < LocoMotion::BaseComponent
+      def initialize(**kws)
+        super
+
+        @custom_option = config_option(:custom_option, "default")
+        @another_option = config_option(:another_option, nil)
+      end
+
+      def call
+        part(:component) do
+          content
+        end
+      end
+    end
+
+    context "creating a customized component" do
+      it "creates a named subclass" do
+        built_class = BuildableComponent.build(custom_option: "built_value")
+        expect(built_class.name).to include("BuildableComponent__Build")
+        expect(built_class.name).not_to eq(BuildableComponent.name)
+      end
+
+      it "creates a different name for each build" do
+        built_class1 = BuildableComponent.build(custom_option: "value1")
+        built_class2 = BuildableComponent.build(custom_option: "value2")
+        expect(built_class1.name).not_to eq(built_class2.name)
+      end
+    end
+
+    context "with build_kws" do
+      it "merges build_kws into the config" do
+        built_class = BuildableComponent.build(custom_option: "built_value")
+        component = built_class.new
+        expect(component.instance_variable_get(:@custom_option)).to eq("built_value")
+      end
+
+      it "allows instance_kws to override build_kws" do
+        built_class = BuildableComponent.build(custom_option: "built_value")
+        component = built_class.new(custom_option: "instance_value")
+        expect(component.instance_variable_get(:@custom_option)).to eq("built_value")
+      end
+
+      it "updates instance variables for build_kws" do
+        built_class = BuildableComponent.build(custom_option: "built_value", another_option: "another_value")
+        component = built_class.new
+        expect(component.instance_variable_get(:@custom_option)).to eq("built_value")
+        expect(component.instance_variable_get(:@another_option)).to eq("another_value")
+      end
+
+      it "does not create instance variables for non-existent keys" do
+        built_class = BuildableComponent.build(non_existent: "value")
+        component = built_class.new
+        expect(component.instance_variable_defined?(:@non_existent)).to be false
+      end
+    end
+
+    context "with skip_styling" do
+      class SkipStylableComponent < LocoMotion::BaseComponent
+        def call
+          part(:component) { content }
+        end
+      end
+
+      it "defaults skip_styling to false when not set" do
+        built_class = SkipStylableComponent.build
+        component = built_class.new
+        expect(component.instance_variable_get(:@skip_styling)).to be false
+      end
+
+      it "sets skip_styling to true when passed via build" do
+        built_class = SkipStylableComponent.build(skip_styling: true)
+        component = built_class.new
+        expect(component.instance_variable_get(:@skip_styling)).to be true
+      end
+
+      it "sets skip_styling to true when passed via instance" do
+        built_class = SkipStylableComponent.build
+        component = built_class.new(skip_styling: true)
+        expect(component.instance_variable_get(:@skip_styling)).to be true
+      end
+    end
+
+    context "with sidecar_files delegation" do
+      it "delegates sidecar_files to superclass" do
+        built_class = BuildableComponent.build(custom_option: "value")
+        expect(built_class).to respond_to(:sidecar_files)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## Context
The Join component required manual addition of the <code>join-item</code> CSS class to each element, which was error-prone and inconsistent with DaisyUI patterns. Additionally, the RadioButton and Checkbox components lacked label support (start/end labels) that are common in form inputs. The BaseComponent.build method also needed improvements to better handle instance variable updates from build_kws.

## Related Issues
None

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition
- [x] Test update/addition

## Description
This PR adds label support to RadioButton and Checkbox components using the LabelableComponent concern, improves the BaseComponent.build method for better instance variable handling, and enhances the Join component with automatic CSS class injection for items, buttons, and radios.

**Key changes:**

- Added LabelableComponent to <code>Daisy::DataInput::RadioButtonComponent</code> and <code>Daisy::DataInput::CheckboxComponent</code>
- Moved RadioButtonComponent rendering from call method to HAML template to match CheckboxComponent pattern
- Added start and end label support with custom content blocks
- Improved <code>LocoMotion::BaseComponent.build</code> method to:
  - Merge build_kws into config before initialize for proper precedence
  - Update instance variables for build_kws keys after initialize
  - Ensure options like <code>skip_styling</code> are available during <code>setup_component</code>
- Updated <code>Daisy::Layout::JoinComponent</code> to:
  - Use <code>BasicComponent.build(css: "join-item")</code> for automatic join-item CSS on items
  - Add <code>renders_many :buttons</code> using <code>ButtonComponent.build(css: "join-item")</code>
  - Add <code>renders_many :radios</code> using <code>RadioButtonComponent.build(skip_styling: true, css: "join-item btn")</code>
  - Updated call method to handle items, buttons, radios, or direct content
- Updated documentation and examples to reflect automatic CSS class behavior
- Added comprehensive tests for label rendering, automatic CSS classes, and build method behavior
- Updated demo examples for joins to use <code>with_button</code> and enhanced direct content example with input, select, and indicator components

**Files modified:**
- <code>app/components/daisy/data_input/checkbox_component.rb</code>
- <code>app/components/daisy/data_input/radio_button_component.rb</code>
- <code>app/components/daisy/data_input/radio_button_component.html.haml</code>
- <code>app/components/daisy/layout/join_component.rb</code>
- <code>lib/loco_motion/base_component.rb</code>
- <code>docs/demo/app/views/examples/daisy/data_input/radio_buttons.html.haml</code>
- <code>docs/demo/app/views/examples/daisy/layout/joins.html.haml</code>
- <code>spec/components/daisy/data_input/radio_button_component_spec.rb</code>
- <code>spec/components/daisy/layout/join_component_spec.rb</code>
- <code>spec/lib/loco_motion/base_component_spec.rb</code>

## Checklist
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)