### PR TITLE
fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 grid layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ releases** should be considered **breaking**!
 - feat(Alert): Add AlertController to NPM package for client-side alert management
 - feat(Configuration): Add comprehensive documentation to Configuration class
 - add(FAB): Add new `Daisy::Actions::FabComponent` (`daisy_fab`) implementing the DaisyUI FAB / Speed Dial pattern with `button`, `activator`, and `action` slots ([Fixes #93](https://github.com/profoundry-us/loco_motion/issues/93))
+- fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 by removing dead `!mt-0` hack and moving sizing to the container via `css:` (override `aspect-ratio`, `max-width`, `border-radius`) instead of `display_css` ([Fixes #99](https://github.com/profoundry-us/loco_motion/issues/99))
 
 ### General Changes
 

--- a/app/components/daisy/mockup/device_component.rb
+++ b/app/components/daisy/mockup/device_component.rb
@@ -21,8 +21,9 @@
 #         class: "rounded-lg")
 #
 # @loco_example Tablet without Camera
-#   = daisy_device(css: "mockup-phone border-primary",
-#     display_css: "overflow-auto w-[736px] h-[414px]", show_camera: false) do
+#   = daisy_device(css: "mockup-phone border-primary max-w-none
+#     w-[600px] aspect-[16/10] rounded-[30px]",
+#     display_css: "overflow-auto rounded-[24px]", show_camera: false) do
 #     .flex.flex-col.gap-4.p-4.bg-white
 #       Tablet Content Here
 #
@@ -59,7 +60,6 @@ class Daisy::Mockup::DeviceComponent < LocoMotion::BaseComponent
   def before_render
     add_css(:camera, "mockup-phone-camera")
     add_css(:display, "mockup-phone-display")
-    add_css(:display, "!mt-0") if !@show_camera
   end
 
   #

--- a/docs/demo/app/views/examples/daisy/mockup/devices.html.haml
+++ b/docs/demo/app/views/examples/daisy/mockup/devices.html.haml
@@ -9,7 +9,7 @@
       You can use the `daisy_device` component to display a phone mockup.
 
   = daisy_device(css: "mockup-phone", display_css: "overflow-auto") do
-    .flex.flex-col.gap-4.p-4.pt-12.pb-8.bg-base-100
+    .flex.flex-col.gap-4.p-4.pt-14.pb-8.bg-base-100
       .text-center.text-2xl.font-bold
         Beautiful Landscapes
       = image_tag("landscapes/beach.jpg", class: "rounded-lg")
@@ -21,10 +21,13 @@
 = doc_example(title: "Tablet") do |doc|
   - doc.with_description do
     :markdown
-      You can also hide the camera by passing `show_camera: false` to the
-      component and add any colors you want to the device.
+      You can simulate a tablet by hiding the camera (`show_camera: false`)
+      and overriding the container's aspect ratio, max-width, and border
+      radius. Because DaisyUI v5 uses CSS Grid for the phone mockup layout,
+      the sizing must be applied to the container via `css:`, not the inner
+      display.
 
-  = daisy_device(css: "mockup-phone border-red-600", display_css: "overflow-auto w-[736px] h-[414px]", show_camera: false) do
+  = daisy_device(css: "mockup-phone border-primary max-w-none w-[600px] aspect-[16/10] rounded-[30px]", display_css: "overflow-auto rounded-[24px]", show_camera: false) do
     .flex.flex-col.gap-4.p-4.bg-base-100
       .text-center.text-2xl.font-bold
         Beautiful Landscapes


### PR DESCRIPTION
## Context

DaisyUI v5 changed `mockup-phone` from a flex/flow layout to CSS Grid.
Both `mockup-phone-camera` and `mockup-phone-display` now use
`grid-area:1/1/1/1` and overlay in the same grid cell, so the old
`!mt-0` hack (applied to the display when `show_camera: false`) no
longer does anything. The deeper problem was that the container enforces
`aspect-ratio:462/978` (portrait) and `max-width:462px`, which constrained
the display to a portrait phone shape regardless of what was set in
`display_css`. The fix moves all tablet sizing to the container via
the `css:` param.

## Related Issues

Fixes #99

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Removed dead `add_css(:display, "!mt-0") if !@show_camera` from
  <code>before_render</code> — no margin exists to override in v5's
  grid layout
- Updated tablet demo and YARD example to override container properties
  via `css:`: `max-w-none`, `w-[600px]`, `aspect-[16/10]`,
  `rounded-[30px]`; display gets matching `rounded-[24px]` via
  `display_css:`
- Updated demo description to explain the DaisyUI v5 grid layout
  requirement so users know to size the container, not the display

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)