### PR TITLE
fix(Skeleton): Fix incorrect colors and add skeleton-text support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ releases** should be considered **breaking**!
 - feat(Join): Update call method to handle items, buttons, radios, or direct content
 - fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES` constant so `diff-item-1` / `diff-item-2` are detected as string literals by Tailwind v4's Ruby extractor ([Fixes #82](https://github.com/profoundry-us/loco_motion/issues/82))
 - add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent` ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
+- fix(Avatar): Suppress `where:bg-neutral` default on placeholder wrapper when `skeleton` is in `wrapper_css`, preventing the neutral background from bleeding through the skeleton shimmer gradient ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
+- fix(Skeleton): Standardize text-hiding in component skeleton examples (`text-transparent` consistently); add `skeleton-text` example and docs for DaisyUI 5's animated text shimmer class ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
 - feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
 - feat(Navbar): Allow custom content to be passed directly inside the component's block in addition to the existing `start`, `center`, and `end` slots ([Fixes #83](https://github.com/profoundry-us/loco_motion/issues/83))
 - feat(Alert): Add auto-dismiss functionality with `autoclose` and `timeout` parameters

--- a/app/components/daisy/data_display/avatar_component.rb
+++ b/app/components/daisy/data_display/avatar_component.rb
@@ -8,6 +8,14 @@
 # It utilizes the CSS `where()` pseudo-class to reduce the specificity to 0 to
 # allow for easy overriding while giving you some sane defaults.
 #
+# @note When using a placeholder avatar (no `src` or `icon`), the wrapper
+#   defaults to `where:bg-neutral where:text-neutral-content` so the
+#   placeholder text is readable. These defaults are suppressed whenever
+#   `skeleton` appears in `wrapper_css`, allowing the skeleton shimmer to
+#   render correctly without the neutral background bleeding through.
+#   Use `wrapper_css: "skeleton"` to display a properly colored skeleton
+#   avatar.
+#
 # @part wrapper The outer container that maintains the avatar's shape and size.
 # @part img The image element when an image source is provided.
 # @part icon The icon element when an icon is specified.
@@ -83,7 +91,12 @@ class Daisy::DataDisplay::AvatarComponent < LocoMotion::BaseComponent
       add_html(:img, { src: @src, title: @content })
     else
       add_css(:component, "avatar-placeholder")
-      add_css(:wrapper, "where:bg-neutral where:text-neutral-content")
+
+      # Suppress neutral defaults when skeleton is present — where:bg-neutral
+      # bleeds through skeleton's transparent gradient due to CSS layer order.
+      unless config_option(:wrapper_css).to_s.match?(/\bskeleton/)
+        add_css(:wrapper, "where:bg-neutral where:text-neutral-content")
+      end
     end
 
     # Concern setup is handled by BaseComponent hook via super in before_render

--- a/app/components/daisy/feedback/skeleton_component.rb
+++ b/app/components/daisy/feedback/skeleton_component.rb
@@ -14,8 +14,12 @@
 #   = daisy_skeleton(css: "w-36 h-20")
 #   = daisy_skeleton(css: "w-48 h-5")
 #
+# @loco_example Skeleton Text
+#   %span.skeleton.skeleton-text.text-2xl.font-bold AI is thinking...
+#   %span.skeleton.skeleton-text.text-base Loading your content...
+#
 # @loco_example Component Loading States
-#   = daisy_badge(css: "badge-lg skeleton text-slate-400") do
+#   = daisy_badge(css: "badge-lg skeleton text-transparent") do
 #     Loading...
 #
 #   = daisy_button(css: "skeleton text-transparent") do
@@ -40,8 +44,10 @@ class Daisy::Feedback::SkeletonComponent < LocoMotion::BaseComponent
   #   - Dimensions: `w-24`, `h-20`
   #   - Shapes: `rounded-full`, `rounded-lg`
   #   - Colors: `bg-base-200`
-  #   When using with other components, combine with `text-transparent` to
-  #   hide placeholder text.
+  #   - Text shimmer: `skeleton-text` (animates text with the shimmer
+  #     gradient — use alongside `skeleton` on the same element)
+  #   When using with other components, combine with `text-transparent`
+  #   to hide placeholder text.
   #
   def before_render
     add_css(:component, "skeleton")

--- a/docs/demo/app/views/examples/daisy/feedback/skeletons.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/skeletons.html.haml
@@ -55,7 +55,7 @@
       = daisy_button(css: "skeleton text-transparent") do
         Loading...
 
-      = daisy_button(css: "skeleton text-transparent") do
+      = daisy_button(css: "skeleton skeleton-text") do
         Loading...
 
     = daisy_alert(css: "skeleton")

--- a/docs/demo/app/views/examples/daisy/feedback/skeletons.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/skeletons.html.haml
@@ -21,15 +21,33 @@
       = daisy_skeleton(css: "#{width} h-5")
 
 
+= doc_example(title: "Skeleton Text") do |doc|
+  - doc.with_description do
+    :markdown
+      Use `skeleton-text` alongside `skeleton` to animate placeholder text
+      with the same shimmer gradient. This is useful for text-only loading
+      states such as AI-generated content or dynamic labels.
+
+  .flex.flex-col.gap-4.w-72
+    %span.skeleton.skeleton-text.text-2xl.font-bold AI is thinking...
+    %span.skeleton.skeleton-text.text-base Loading your content...
+    %span.skeleton.skeleton-text.text-sm.w-48 Fetching results...
+
+
 = doc_example(title: "Component Skeletons") do |doc|
   - doc.with_description do
     :markdown
       You can also use skeletons to show placeholders for components by adding
       the `skeleton` class to many existing components.
 
+      When applying a skeleton to a placeholder avatar (one with no `src` or
+      `icon`), pass `wrapper_css: "skeleton"` — the avatar component detects
+      the `skeleton` class and automatically suppresses its default
+      `bg-neutral` so the skeleton shimmer color shows correctly.
+
   .flex.flex-col.gap-8
     .flex.items-center.gap-8
-      = daisy_badge(css: "badge-lg skeleton text-base-content/50") do
+      = daisy_badge(css: "badge-lg skeleton text-transparent") do
         Loading...
 
       .w-12.md:w-48

--- a/docs/demo/e2e/daisy/feedback/skeletons.spec.ts
+++ b/docs/demo/e2e/daisy/feedback/skeletons.spec.ts
@@ -1,16 +1,25 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { loco } from '../../spec_helpers';
 
+test.beforeEach(async ({ page }) => {
+  await page.goto('/examples/Daisy::Feedback::SkeletonComponent');
+});
+
 test('page loads', async ({ page }) => {
-  await page.goto('/');
-
-  // Click the Skeletons nav link
-  await loco.clickNavLink(page, 'Skeletons');
-
-  // Expect the title and key headings
   await loco.expectPageTitle(page, /Skeletons | LocoMotion/);
   await loco.expectPageHeadings(page, [
     'Basic Skeletons',
+    'Skeleton Text',
     'Component Skeletons'
   ]);
+});
+
+test('chat avatar skeleton does not have neutral background class', async ({ page }) => {
+  // When wrapper_css includes "skeleton", AvatarComponent suppresses the
+  // where:bg-neutral where:text-neutral-content defaults so the skeleton
+  // shimmer color shows correctly. Guard against that fix regressing.
+  const avatarWrapper = page.locator('.chat-image > div.skeleton').first();
+
+  await expect(avatarWrapper).toBeVisible();
+  await expect(avatarWrapper).not.toHaveClass(/where:bg-neutral/);
 });

--- a/docs/plans/202605-1-fix-skeleton-colors.md
+++ b/docs/plans/202605-1-fix-skeleton-colors.md
@@ -1,0 +1,106 @@
+
+# Fix Skeleton Colors (Issue #98)
+
+## Overview
+
+Skeleton elements show incorrect or inconsistent colors on the demo site
+when applied to existing components (badge, button, alert, chat). The root
+causes are:
+
+1. Inconsistent text-hiding strategies across components (`text-transparent`
+   on buttons/chat vs `text-base-content/50` on badge).
+2. DaisyUI 5 introduced a `skeleton-text` utility class that animates text
+   color using the same shimmer gradient as `skeleton`, which should replace
+   the ad-hoc `text-transparent` / `text-base-content/50` approaches.
+
+The demo app's DaisyUI is already at v5.5.19 (which includes `skeleton-text`),
+so no package upgrade is required.
+
+Fixes #98 — https://github.com/profoundry-us/loco_motion/issues/98
+
+## External Resources
+
+- DaisyUI Skeleton docs: https://daisyui.com/components/skeleton/
+- `skeleton-text` CSS:
+  `docs/demo/node_modules/daisyui/components/skeleton.css`
+
+## Implementation Steps
+
+### 1. Update Example View
+
+**Purpose**: Replace ad-hoc text-hiding classes with `skeleton-text` for
+visual consistency, matching DaisyUI 5's intended usage pattern.
+
+**File to Edit**:
+`docs/demo/app/views/examples/daisy/feedback/skeletons.html.haml`
+
+**Changes to Make**:
+
+- On the `daisy_badge` line: replace `text-base-content/50` with
+  `skeleton-text`.
+- On both `daisy_button` lines: replace `text-transparent` with
+  `skeleton-text`.
+- On the `daisy_chat` bubble lines: replace `text-transparent` with
+  `skeleton-text`.
+- Visually review in the running demo to confirm the shimmer gradient looks
+  correct on each component. Adjust any remaining background-color conflicts
+  (e.g. add `bg-transparent` or another override) if a component's own
+  background obscures the skeleton shimmer.
+
+### 2. Update Component YARD Docs
+
+**Purpose**: Keep the inline code examples in the component class consistent
+with the updated demo and document `skeleton-text` as the recommended
+approach.
+
+**File to Edit**:
+`app/components/daisy/feedback/skeleton_component.rb`
+
+**Changes to Make**:
+
+- In the `@loco_example Component Loading States` block, replace
+  `text-transparent` and `text-slate-400` / `text-base-content/50` with
+  `skeleton-text` across all usages.
+- In the `@option kws css` description, remove the mention of
+  `text-transparent` and add `skeleton-text` as the recommended class for
+  hiding placeholder text.
+
+### 3. Update RSpec Tests
+
+**Purpose**: Add a test context that documents the `skeleton-text` usage
+pattern so it doesn't regress.
+
+**File to Edit**:
+`spec/components/daisy/feedback/skeleton_component_spec.rb`
+
+**Changes to Make**:
+
+- Rename or update the existing `"with hidden text"` context (currently
+  uses `text-transparent`) to use `skeleton-text` instead, since that is
+  now the preferred class.
+- Update any assertions that reference `text-transparent` to reference
+  `skeleton-text`.
+
+### 4. Verification
+
+**Purpose**: Confirm colors look correct in the live demo and all tests pass.
+
+**Commands to Run**:
+
+```bash
+just loco-test
+```
+
+```bash
+docker compose exec -it demo yarn playwright test \
+  'e2e/feedback/skeletons' --reporter dot --workers 1
+```
+
+**Expected Results**:
+
+- All skeleton shapes render with the expected `bg-base-300` shimmer.
+- Badge, button, alert, and chat skeletons show a uniform color — no
+  component-specific background bleeding through.
+- Placeholder text in buttons/chat/badge animates with the shimmer gradient
+  via `skeleton-text`, matching the DaisyUI 5 design intent.
+- RSpec suite passes with no failures.

--- a/spec/components/daisy/feedback/skeleton_component_spec.rb
+++ b/spec/components/daisy/feedback/skeleton_component_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Daisy::Feedback::SkeletonComponent, type: :component do
     end
   end
 
-  context "with hidden text" do
+  context "with hidden text using text-transparent" do
     let(:content) { "Loading..." }
     let(:skeleton) { described_class.new(css: "text-transparent") }
 
@@ -99,8 +99,31 @@ RSpec.describe Daisy::Feedback::SkeletonComponent, type: :component do
     end
   end
 
+  context "with animated text using skeleton-text" do
+    let(:content) { "AI is thinking..." }
+    let(:skeleton) { described_class.new(css: "skeleton-text") }
+
+    before do
+      render_inline(skeleton) { content }
+    end
+
+    describe "rendering" do
+      it "includes skeleton-text class" do
+        expect(page).to have_selector(".skeleton.skeleton-text")
+      end
+
+      it "maintains default skeleton class" do
+        expect(page).to have_selector(".skeleton")
+      end
+
+      it "still renders the content" do
+        expect(page).to have_content(content)
+      end
+    end
+  end
+
   context "with multiple classes" do
-    let(:classes) { "w-36 h-20 rounded-lg text-transparent" }
+    let(:classes) { "w-36 h-20 rounded-lg skeleton-text" }
     let(:skeleton) { described_class.new(css: classes) }
 
     before do


### PR DESCRIPTION
## Context

In DaisyUI 5, the `skeleton` class applies its `background-color` inside a
nested CSS sub-layer (`@layer daisyui.l1.l2.l3`). The `AvatarComponent`'s
placeholder default (`where:bg-neutral`) lives in the unlayered portion of
`@layer utilities`, which always takes cascade precedence over nested
sub-layers — regardless of the `:where()` zero-specificity wrapper. This
caused chat avatar circles to render dark (neutral) instead of the expected
light skeleton shimmer.

A second, unrelated issue: the skeleton demo used `text-base-content/50` on
the badge example but `text-transparent` everywhere else, causing visual
inconsistency across component skeletons.

## Related Issues

Fixes #98

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [x] Test update/addition
- [ ] Other (please describe):

## Description

- `AvatarComponent`: suppress `where:bg-neutral where:text-neutral-content`
  on the placeholder wrapper whenever `skeleton` appears in `wrapper_css`;
  `wrapper_css: "skeleton"` now just works with no extra classes needed
- `AvatarComponent`: add `@note` documenting the behavior
- `SkeletonComponent`: add `@loco_example Skeleton Text` showing DaisyUI 5's
  `skeleton-text` class for animated text loading states
- `SkeletonComponent`: fix `@loco_example Component Loading States` — badge
  was using `text-slate-400`, now consistently uses `text-transparent`
- `SkeletonComponent`: document `skeleton-text` in the `@option css` block
- Skeletons demo: add a "Skeleton Text" example section
- Skeletons demo: replace `text-base-content/50` with `text-transparent` on
  badge for consistency; add explanatory note about avatar skeleton usage
- Skeleton spec: add `"with animated text using skeleton-text"` context; update
  `"with multiple classes"` to use `skeleton-text`
- Playwright spec: add regression test verifying avatar wrapper does not carry
  `where:bg-neutral` when rendered as a skeleton; update headings check

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)