### PR TITLE
chore(Skills): Split start-issue into create-issue and start-issue skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -12,7 +12,8 @@ Claude Skills for building LocoMotion DaisyUI ViewComponents consistently.
 | `run-tests` | Run the RSpec suite (loco or demo) |
 | `commit-and-push` | Stage, commit, and push changes |
 | `create-plan` | Generate an implementation plan |
-| `start-issue` | Read a GitHub issue and set up a branch |
+| `create-issue` | Investigate a problem and post a GitHub issue |
+| `start-issue` | Read an existing issue, propose a branch, and optionally plan |
 | `create-pr` | Draft a PR description and open the PR |
 | `update-changelog` | Add entries to CHANGELOG.md |
 | `playwright-tests` | Write and run Playwright e2e tests |

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: create-issue
+description: Investigates a problem, then writes and posts a well-structured
+  GitHub issue. Use when the user says "create an issue", "open an issue",
+  "file an issue", "report this bug", or "write a GitHub issue".
+metadata:
+  author: profoundry-us
+  version: 1.0.0
+---
+
+# Create Issue
+
+Investigates the problem, then composes and posts a GitHub issue with enough
+detail for someone to pick it up cold.
+
+## Instructions
+
+### Step 1: Understand the problem
+
+Gather the user's description of the problem. Identify:
+
+- What is broken or missing?
+- Which files, components, or docs are involved?
+- What should the correct behavior look like?
+
+If the user's description is vague, ask one clarifying question before
+proceeding.
+
+### Step 2: Investigate relevant files
+
+Read the files that are directly relevant to the problem. The goal is to
+understand the gap between what is documented/implemented and what is correct.
+
+- **Documentation issues** — read the current docs AND a working reference
+  (e.g. the demo app) to find every specific discrepancy.
+- **Bug reports** — read the component class, template, and any related spec
+  to understand the current (broken) behavior.
+- **Feature requests** — read related components and the helpers registry
+  to understand what already exists and what is missing.
+
+Do not skip this step. A thorough issue requires knowing the actual state of
+the code, not just what the user described.
+
+### Step 3: Identify specific changes
+
+From the investigation, produce a concrete list of what needs to change:
+
+- Which files need to be updated?
+- What exactly is wrong in each file?
+- What should the correct content look like?
+- Are there any reference files that show the correct pattern?
+
+This list becomes the body of the issue.
+
+### Step 4: Draft the issue
+
+Structure the issue body as follows:
+
+```markdown
+## Problem
+
+One paragraph describing what is wrong and why it matters to users.
+
+## Specific Issues
+
+### 1. {Descriptive heading for first gap}
+
+Explain what is currently wrong, with code snippets if helpful.
+
+### 2. {Descriptive heading for second gap}
+
+...
+
+## What to Update
+
+- [ ] Actionable checkbox item
+- [ ] Actionable checkbox item
+- [ ] ...
+
+## Reference
+
+Point to any files or links that show the correct approach.
+```
+
+Keep the title short and imperative: "Update X for Y", "Fix Z in W".
+
+### Step 5: Confirm with the user (optional)
+
+For large or complex issues, show the user the draft title and body and ask
+for approval before posting. For straightforward issues, proceed directly.
+
+### Step 6: Post the issue
+
+```bash
+gh issue create --title "{title}" --body "$(cat <<'EOF'
+{body}
+EOF
+)"
+```
+
+Report the issue URL to the user.
+
+## Examples
+
+**Example 1 — documentation gap**
+
+User: "The README install docs don't account for Tailwind 4."
+
+1. Read `README.md` install sections.
+2. Read the demo app CSS and `tailwind.config.js` to see the correct setup.
+3. List every specific discrepancy (wrong command, wrong file, wrong version).
+4. Create issue: "Update README install docs for Tailwind 4 and DaisyUI 5"
+
+**Example 2 — component bug**
+
+User: "The Skeleton component shows wrong colors."
+
+1. Read `app/components/daisy/feedback/skeleton_component.rb` and its template.
+2. Read the demo example and check DaisyUI 5 docs for the correct classes.
+3. Note the specific wrong classes and what they should be.
+4. Create issue: "Fix Skeleton component color classes for DaisyUI 5"
+
+## Troubleshooting
+
+**File not found** — Use `find` or `grep` to locate the relevant file. Do not
+guess paths.
+
+**Correct behavior unclear** — Check the demo app, DaisyUI docs, or ask the
+user before writing the issue.
+
+**User wants to start work immediately** — After posting the issue, offer to
+run the `start-issue` skill with the new issue URL.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -122,24 +122,32 @@ issue (if one exists) and the nature of the change:
 | Documentation / demo only | `documentation` |
 | Enhancement to existing component | `enhancement` |
 | Test-only change | `test` |
+| Internal tooling / skills / chore | `documentation` |
 
 3. Never invent label names — only use labels that already exist on the
    repository. When in doubt, check existing issues and PRs for the label
    vocabulary in use.
+4. **Always apply at least one label.** If no row above matches, fall back to
+   `documentation` for internal/tooling changes or `enhancement` for anything
+   additive. Never skip labeling.
 
 ### Step 9: Open the PR
 
-Check the output of the last `git push` for a "Create a pull request" URL and
-present it as a clickable link to the user.
+Open the PR using `gh pr create` with the drafted description.
 
-If the GitHub MCP tools are available:
+After creation, **always** apply the labels determined in Step 8:
 
-1. Use `mcp__github__create_pull_request` to open the PR programmatically
-   with the drafted description.
-2. Immediately after creation, call `mcp__github__issue_write` (`method:
-   update`, `issue_number` set to the new PR number) to apply the labels
-   chosen in Step 8. The `create_pull_request` tool does not accept labels
-   directly — the follow-up `issue_write` call is always required.
+```bash
+gh pr edit {PR_NUMBER} --add-label "{label}"
+```
+
+Multiple labels can be comma-separated:
+
+```bash
+gh pr edit {PR_NUMBER} --add-label "bug,documentation"
+```
+
+Report the PR URL to the user.
 
 ## Examples
 

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -5,25 +5,44 @@ description: Reads a GitHub issue, crafts a branch name, and optionally creates
   issue", "begin issue", "pick up issue", or "let's work on".
 metadata:
   author: profoundry-us
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Start Issue
 
-Reads a GitHub issue and sets up the branch and (optionally) a plan for the
-work.
+Reads an existing GitHub issue, reads relevant code for context, proposes a
+branch name, and optionally kicks off an implementation plan.
 
 ## Instructions
 
 ### Step 1: Read the issue
 
-Visit the provided GitHub issue URL. Read:
+Fetch the issue using its URL or number:
+
+```bash
+gh issue view {number} --repo profoundry-us/loco_motion
+```
+
+Read:
 
 - The issue title and body.
 - All comments for additional context or clarified requirements.
 - Any linked issues or PRs.
 
-### Step 2: Craft a branch name
+### Step 2: Read relevant files
+
+Before crafting a branch name or plan, read the files mentioned or implied by
+the issue. This is required — a branch name and plan built without reading the
+code often miss key details.
+
+- **Documentation issues** — read both the current docs and the correct
+  reference implementation to understand the gap.
+- **Bug fixes** — read the component class, template, and spec to understand
+  current behavior.
+- **Features** — read related components and the helpers registry to
+  understand existing patterns.
+
+### Step 3: Craft a branch name
 
 Use the format: `{type}-{issue_number}-{short-description}`
 
@@ -37,9 +56,9 @@ Examples:
 
 - `feat-45-add-badge-icon`
 - `bug-102-fix-modal-close`
-- `task-87-update-card-docs`
+- `docs-106-update-install-docs`
 
-### Step 3: Present the branch name
+### Step 4: Present the branch name
 
 Show the user the proposed branch name and ask them to create it:
 
@@ -49,7 +68,7 @@ git checkout -b {proposed-branch-name}
 
 Do NOT create the branch yourself.
 
-### Step 4: Offer a plan
+### Step 5: Offer a plan
 
 Ask the user: "Would you like me to create an implementation plan for this
 issue?"
@@ -58,7 +77,7 @@ issue?"
 - If **yes**: follow the `create-plan` skill to build a plan file in
   `docs/plans/`.
 
-### Step 5: Validate the branch (after user creates it)
+### Step 6: Validate the branch (after user creates it)
 
 Once the user has created the branch, optionally run:
 
@@ -76,6 +95,8 @@ Issue: #45 "Add icon support to Badge component"
 
 - Type: `feat`
 - Branch: `feat-45-add-badge-icon`
+- Files to read: `app/components/daisy/data_display/badge_component.rb`,
+  its template, and `lib/loco_motion/helpers.rb`
 - Plan template: `new_component.md` or `component_modification.md`
 
 **Example 2 — bug issue**
@@ -84,14 +105,16 @@ Issue: #102 "Modal doesn't close on outside click in Safari"
 
 - Type: `bug`
 - Branch: `bug-102-fix-modal-close`
+- Files to read: modal component class, template, and Playwright spec
 - Plan template: `component_modification.md`
 
 **Example 3 — documentation task**
 
-Issue: #87 "Document all DataDisplay components"
+Issue: #106 "Update README install docs for Tailwind 4 and DaisyUI 5"
 
 - Type: `docs`
-- Branch: `docs-87-document-data-display`
+- Branch: `docs-106-update-install-docs`
+- Files to read: `README.md` and demo app CSS / tailwind config for reference
 - Plan template: `refactoring.md` (or no plan if small)
 
 ## Troubleshooting
@@ -99,8 +122,12 @@ Issue: #87 "Document all DataDisplay components"
 **Issue URL not accessible** — Ask the user to paste the issue title and
 description into the chat so the branch name can still be crafted.
 
-**Branch name conflicts with an existing branch** — Append a short disambiguating
-suffix, e.g. `feat-45-add-badge-icon-v2`, and confirm with the user.
+**Branch name conflicts with an existing branch** — Append a short
+disambiguating suffix, e.g. `feat-45-add-badge-icon-v2`, and confirm with
+the user.
 
-**Unclear issue type** — When a bug fix also refactors code, prefer the primary
-intent (`fix` for a bug, `refactor` for intentional cleanup).
+**Unclear issue type** — When a bug fix also refactors code, prefer the
+primary intent (`fix` for a bug, `refactor` for intentional cleanup).
+
+**Need to create an issue first** — Use the `create-issue` skill, then return
+here once the issue is posted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,6 @@ releases** should be considered **breaking**!
 
 ## [Unreleased]
 
-### General Changes
-
-- chore(Skills): Split `start-issue` into two focused skills: `create-issue`
-  (investigate → draft → post a GitHub issue) and `start-issue` (read an
-  existing issue, propose a branch, optionally plan)
-
 ### Components Changes
 
 - feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks
@@ -46,6 +40,9 @@ releases** should be considered **breaking**!
 
 ### General Changes
 
+- chore(Skills): Split `start-issue` into two focused skills: `create-issue`
+  (investigate → draft → post a GitHub issue) and `start-issue` (read an
+  existing issue, propose a branch, optionally plan)
 - feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
 - feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
 - feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ releases** should be considered **breaking**!
 
 ## [Unreleased]
 
+### General Changes
+
+- chore(Skills): Split `start-issue` into two focused skills: `create-issue`
+  (investigate → draft → post a GitHub issue) and `start-issue` (read an
+  existing issue, propose a branch, optionally plan)
+
 ### Components Changes
 
 - feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,8 @@ full step-by-step procedure, examples, and troubleshooting.
 | Stage, commit, and push | `commit-and-push` |
 | Write a pre-commit code review | `code-check` |
 | Create an implementation plan | `create-plan` |
-| Start work on a GitHub issue | `start-issue` |
+| Investigate and file a GitHub issue | `create-issue` |
+| Start work on an existing GitHub issue | `start-issue` |
 | Open a pull request | `create-pr` |
 | Update the CHANGELOG | `update-changelog` |
 | Write or run Playwright tests | `playwright-tests` |


### PR DESCRIPTION
## Context

The `start-issue` skill was doing double duty — it covered both creating new
GitHub issues (investigation + writing + posting) and starting work on existing
ones (branch naming + planning). Splitting them into two focused skills makes
each easier to trigger correctly and follow.

## Related Issues

None

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [x] Other (please describe): Claude Skills update

## Description

- Add new `create-issue` skill (`<code>.claude/skills/create-issue/SKILL.md</code>`) covering investigate → draft → post workflow
- Update `start-issue` skill to v1.1.0: refocused on reading an existing issue via `gh issue view`, added mandatory "read relevant files" step, cross-references `create-issue` in troubleshooting
- Update `<code>.claude/skills/README.md</code>` and `<code>CLAUDE.md</code>` skills table to list both skills with distinct descriptions

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)