### PR TITLE
docs: Update README for Tailwind 4 / DaisyUI 5 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,13 @@ ViewComponent, TailwindCSS, DaisyUI and more!
 <img src="//loco-motion-docs.profoundry.us/images/loco-chats.png" width="500px" style="border: 1px solid #bbb; padding: 2px; border-radius: 10px;">
 
 <!-- omit from toc -->
-## DISCLAIMER / CURRENT STATUS
+## Current Status
 
 This project is in active development and many changes occur with every release!
 
-We've added a very basic / untested version of all DaisyUI 4 components. While
-we originally intended to take some time to flesh out and attempt to use these
-components, with the recent release of Tailwind 4 and DaisyUI 5, we feel our
-time is best spent updating all of the components and dependencies for these
-new releases.
-
-This means that we will **NOT** be making any bug fixes to the current branch
-(0.4.0), and will instead include any bug fixes / improvements into the 0.5.0
-branch which will also upgrade to Tailwind 4 and DaisyUI 5.
-
- - Current Release **(0.4.0)** - Works with DaisyUI 4 and Tailwind 3
- - Next Release **(0.5.0)** - Will work with DaisyUI 5 and Tailwind 4
+As of **v0.5.x**, LocoMotion ships with **Tailwind 4** and **DaisyUI 5**. The
+install approach has changed from previous versions — please follow the updated
+instructions below.
 
 <!-- omit from toc -->
 ## Additional Notes
@@ -30,11 +21,9 @@ branch which will also upgrade to Tailwind 4 and DaisyUI 5.
 ### DataInput Components
 
 Many of the DataInput elements (file input, text input, select dropdown, etc)
-were built rather hastily so that we would have a base version to start from.
-
-However, the new DaisyUI 5 components are implemented in a much cleaner way and
-we didn't want to invest too much time building these out and making them more
-ideal since we're about to change them.
+were built as a base version to start from. DaisyUI 5 redesigned these
+components significantly, so they are being incrementally improved as we use
+them in real projects.
 
 ### Hosting / Sites
 
@@ -342,25 +331,34 @@ scratch, we recommend that you stick with Tailwind by itself.
 However, if you're working on a project and want a good starting point for UI
 components, you might checkout DaisyUI or a simliar Tailwind-based UI library.
 
-DaisyUI is a plugin for Tailwind, so installing it is dead simple. Just open up
-an app shell by running `just app-shell` in the terminal and run the following
-command:
+With Tailwind 4, DaisyUI is configured directly in your CSS file rather than
+in `tailwind.config.js`. Open an app shell with `just app-shell` and install
+the packages:
 
 ```shell
-yarn add daisyui@latest --dev
+yarn add tailwindcss @tailwindcss/cli daisyui
 ```
 
-Next, edit your `tailwind.config.js` file to add it as a plugin:
+Then open your `application.tailwind.css` (or `application.css`) and add the
+`@import` and `@plugin` directives:
+
+```css
+/* Import the base Tailwind theme */
+@import 'tailwindcss';
+
+/* Include DaisyUI via @plugin directive */
+@plugin 'daisyui' {
+  themes: light --default, dark --prefersdark;
+}
+
+/* Point to tailwind.config.js for content scan paths only */
+@config "../tailwind.config.js";
+```
 
 > [!IMPORTANT]
-> Make sure to add a `,` to the previous line if you put it at the bottom.
-
-```js
-module.exports = {
-  //...
-  plugins: [require("daisyui")],
-}
-```
+> Tailwind 4 moves all plugin configuration into the CSS file. Do **not** add
+> DaisyUI to `tailwind.config.js` — that file is now only used to declare
+> content scan paths (see the LocoMotion Install section below).
 
 > [!IMPORTANT]
 > Moving forward, this guide will assume you have installed DaisyUI, so some of
@@ -743,46 +741,41 @@ In addition to the recommendations / suggestions above, LocoMotion also provides
 a full set of UI components to help you build robust and full-featured apps.
 
 > [!CAUTION]
-> The LocoMotion components are being actively developed and are NOT ready for
-> production / public use! We have finished basic versions of the DaisyUI
-> Actions, DataDisplay, Navigation, and Feedback components, but we expect these
-> to change (possibly quite a bit) as we begin to use them in projects.
+> LocoMotion is in active development. Components are functional but APIs may
+> change between minor releases. Pin to a specific version in production.
 
 ### Install
 
 Add the following to your `Gemfile` and re-run `bundle`:
 
-```Gemfile
+```ruby
 # Gemfile
 
-gem "loco_motion", github: "profoundry-us/loco_motion", branch: "main", require: "loco_motion"
-
-# or
-
-gem "loco_motion-rails", "0.4.0", require: "loco_motion"
+gem "loco_motion-rails", "~> 0.5.2", require: "loco_motion"
 ```
 
-Next add the following lines to the `contents` section of your
-`tailwind.config.js` to import / build the proper files:
+Next, create or update your `tailwind.config.js` to tell Tailwind where to
+scan for component class names. In Tailwind 4, this file handles **only**
+content paths — plugins belong in your CSS file (see above).
 
 ```js
-  const { execSync } = require('child_process');
+const { execSync } = require('child_process');
+let locoBundlePath =
+  execSync('bundle show loco_motion-rails').toString().trim();
 
-  let locoBundlePath = execSync('bundle show loco_motion').toString().trim();
-
-  module.exports = {
-    content:[
-      `${locoBundlePath}/app/components/**/*.{rb,js,html.haml}`,
-
-      // ...
-    ]
-  }
+module.exports = {
+  content: [
+    `${locoBundlePath}/app/components/**/*.{rb,js,html,haml}`,
+    'app/components/**/*.{rb,js,html,haml}',
+    'app/views/**/*.{rb,js,html,haml}',
+  ]
+}
 ```
 
 > [!WARNING]
-> Note that this will not output anything if it fails to find the right
-> directory, so your CSS may not compile properly if this command fails or finds
-> the wrong gem or an older gem.
+> Note that `bundle show loco_motion-rails` will output nothing if the gem
+> is not installed or the name is wrong, causing Tailwind to skip all
+> component classes. Make sure the gem name matches exactly.
 
 Next, if you're using any of the components that require JavaScript (like the
 Countdown component), you'll need to add the library as a dependency and include

--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ Then open your `application.tailwind.css` (or `application.css`) and add the
   themes: light --default, dark --prefersdark;
 }
 
+/* Custom variant to reduce selector specificity for component defaults */
+@custom-variant where (:where(&));
+
+/* Custom dark: variant for System-based & DaisyUI ThemeController dark mode */
+@custom-variant dark (@media (prefers-color-scheme: dark), :root:has(input.theme-controller[value=dark]:checked) &);
+
 /* Point to tailwind.config.js for content scan paths only */
 @config "../tailwind.config.js";
 ```

--- a/docs/demo/app/views/docs/02_install.html.haml
+++ b/docs/demo/app/views/docs/02_install.html.haml
@@ -21,7 +21,7 @@
   = doc_code(language: "ruby") do
     :plain
       # Gemfile
-      gem "loco_motion-rails", "~> 0.5.0", require: "loco_motion"
+      gem "loco_motion-rails", "~> 0.5.2", require: "loco_motion"
 
   :markdown
     Or if you want the latest and greatest:
@@ -88,11 +88,36 @@
   :markdown
     ## 3. TailwindCSS Installation
 
-    And finally, all of the components are built on top of TailwindCSS, so we
-    need to notify Tailwind of where to look for our components so that it can
-    properly setup and tree-shake all of our code into a minimal package.
+    LocoMotion uses Tailwind 4, which configures plugins directly in your CSS
+    file rather than in `tailwind.config.js`.
 
-    Add the following to your `tailwind.config.js` file.
+    ### 3a. CSS Setup
+
+    Add the following to your `application.tailwind.css` (or equivalent):
+
+.max-w-prose
+  = doc_code(css: "my-4", language: "css") do
+    :plain
+      /* application.tailwind.css */
+
+      /* Import the base Tailwind theme */
+      @import 'tailwindcss';
+
+      /* Include DaisyUI via @plugin directive */
+      @plugin 'daisyui' {
+        themes: light --default, dark --prefersdark;
+      }
+
+      /* Point to tailwind.config.js for content scan paths */
+      @config "../tailwind.config.js";
+
+.mt-4.prose
+  :markdown
+    ### 3b. Content Path Setup
+
+    Next, create or update your `tailwind.config.js` to tell Tailwind where to
+    scan for class names. In Tailwind 4 this file handles **only** content
+    paths — plugins belong in your CSS file (see above).
 
 .max-w-prose
   = doc_code(css: "my-4", language: "javascript") do
@@ -103,8 +128,6 @@
       // Get the path to the loco_motion gem
       let locoBundlePath = execSync('bundle show loco_motion-rails').toString().trim();
 
-      console.log(" *** Importing LocoMotion gem Components into Tailwind: ", locoBundlePath);
-
       module.exports = {
         content: [
           `${locoBundlePath}/app/components/**/*.{rb,js,html,haml}`,
@@ -112,10 +135,6 @@
           'app/views/**/*.{rb,js,html,haml}',
         ]
       }
-
-  = doc_note(css: "mt-6") do
-    :markdown
-      You can remove the `console.log` once everything is working.
 
 .mt-4.prose
   :markdown
@@ -129,10 +148,7 @@
       // tailwind.config.js
       const { execSync } = require('child_process');
 
-      // Get the path to the loco_motion gem
       let locoBundlePath = execSync('bundle show loco_motion-rails').toString().trim();
-
-      console.log(" *** Importing LocoMotion gem Components into Tailwind: ", locoBundlePath);
 
       module.exports = {
         content: [

--- a/docs/demo/app/views/docs/02_install.html.haml
+++ b/docs/demo/app/views/docs/02_install.html.haml
@@ -108,6 +108,12 @@
         themes: light --default, dark --prefersdark;
       }
 
+      /* Custom variant to reduce selector specificity for component defaults */
+      @custom-variant where (:where(&));
+
+      /* Custom dark: variant for System-based & DaisyUI ThemeController dark mode */
+      @custom-variant dark (@media (prefers-color-scheme: dark), :root:has(input.theme-controller[value=dark]:checked) &);
+
       /* Point to tailwind.config.js for content scan paths */
       @config "../tailwind.config.js";
 
@@ -148,6 +154,7 @@
       // tailwind.config.js
       const { execSync } = require('child_process');
 
+      // Get the path to the loco_motion gem
       let locoBundlePath = execSync('bundle show loco_motion-rails').toString().trim();
 
       module.exports = {

--- a/docs/plans/202605-2-update-readme-install-docs.md
+++ b/docs/plans/202605-2-update-readme-install-docs.md
@@ -1,0 +1,194 @@
+
+# Update README Install Docs for Tailwind 4 / DaisyUI 5 (Issue #106)
+
+## Overview
+
+The README install documentation still describes the Tailwind 3 / DaisyUI 4
+setup process. Since the release of v0.5.x (which ships Tailwind 4 and
+DaisyUI 5), several sections are incorrect or misleading for new users:
+
+1. The "Install DaisyUI" section still shows `tailwind.config.js` plugin
+   setup — this is the Tailwind 3 approach and does not work with Tailwind 4.
+2. The CSS-first `@import tailwindcss` / `@plugin 'daisyui'` approach is
+   not documented at all.
+3. The LocoMotion Install section references `bundle show loco_motion`
+   (wrong gem name — should be `loco_motion-rails`).
+4. The gem version example still shows `0.4.0`; the current release is
+   `0.5.2`.
+5. The DISCLAIMER / CURRENT STATUS section describes 0.5.0 as future work
+   when it has already shipped.
+
+Fixes #106 — https://github.com/profoundry-us/loco_motion/issues/106
+
+## External Resources
+
+- Issue: https://github.com/profoundry-us/loco_motion/issues/106
+- Tailwind 4 CSS-first config docs: https://tailwindcss.com/docs/configuration
+- DaisyUI 5 install docs: https://daisyui.com/docs/install/
+- Working CSS reference:
+  `docs/demo/app/assets/stylesheets/application.tailwind.css`
+- Working config reference: `docs/demo/tailwind.config.js`
+
+## Implementation Steps
+
+### 1. Analyze Current README
+
+**Purpose**: Identify the exact line ranges of each section that needs
+updating so edits are targeted and don't break surrounding content.
+
+**File to Review**: `README.md`
+
+**Key sections and approximate line numbers**:
+
+- `DISCLAIMER / CURRENT STATUS` — lines 10–26
+- `Install DaisyUI (Optional)` — lines 311–368
+- `LocoMotion Install` section (gem version + `tailwind.config.js`) —
+  lines 751–785
+
+### 2. Remove / Rewrite DISCLAIMER Section
+
+**Purpose**: The DISCLAIMER describes 0.5.0 as unreleased future work.
+Since 0.5.x has shipped, this section is misleading. Replace it with a
+brief "current status" note that reflects reality.
+
+**File to Edit**: `README.md`
+
+**Changes to Make**:
+
+- Remove the `<!-- omit from toc -->` DISCLAIMER block (lines 9–26).
+- Replace with a short note (2–4 lines) that states the project ships
+  Tailwind 4 + DaisyUI 5 as of v0.5.x and is in active development.
+- Keep the `<!-- omit from toc -->` directive on the replacement header
+  so the TOC is unaffected.
+
+### 3. Rewrite "Install DaisyUI" Section
+
+**Purpose**: Replace the Tailwind 3 / DaisyUI 4 plugin approach with the
+Tailwind 4 CSS-first approach.
+
+**File to Edit**: `README.md`
+
+**Changes to Make**:
+
+- Replace the `yarn add daisyui@latest --dev` command with the correct
+  Tailwind 4 command (no `--dev`, no `@latest`):
+  ```shell
+  yarn add tailwindcss @tailwindcss/cli daisyui
+  ```
+- Remove the `tailwind.config.js` plugin block
+  (`plugins: [require("daisyui")]`) entirely.
+- Add a new sub-section or note showing the CSS-first setup. Use the demo
+  app's `application.tailwind.css` as the reference. The minimal example
+  for a user app:
+  ```css
+  /* application.tailwind.css */
+
+  /* Import the base Tailwind theme */
+  @import 'tailwindcss';
+
+  /* Include DaisyUI via @plugin directive */
+  @plugin 'daisyui' {
+    themes: light --default, dark --prefersdark;
+  }
+
+  /* Point to tailwind.config.js for content scan paths only */
+  @config "../tailwind.config.js";
+  ```
+- Clarify that `tailwind.config.js` is now minimal — only responsible for
+  `content` scan paths; plugins live in the CSS file.
+- Update the `> [!IMPORTANT]` note that says "Moving forward, this guide
+  will assume you have installed DaisyUI" — keep the intent but adjust
+  wording to reflect DaisyUI 5 / Tailwind 4.
+
+### 4. Update LocoMotion Install Section
+
+**Purpose**: Fix the gem name, version, and `tailwind.config.js` snippet
+so they reflect the current working setup.
+
+**File to Edit**: `README.md`
+
+**Changes to Make**:
+
+- In the Gemfile example, update the pinned version from `0.4.0` to
+  `0.5.2`:
+  ```ruby
+  gem "loco_motion-rails", "~> 0.5.2", require: "loco_motion"
+  ```
+- Remove or update the stale GitHub source line
+  (`github: "profoundry-us/loco_motion", branch: "main"`) — point users
+  to RubyGems instead.
+- Fix the `tailwind.config.js` snippet:
+  - Change `bundle show loco_motion` → `bundle show loco_motion-rails`
+  - Show the minimal content-only config (no `plugins:` key), matching
+    `docs/demo/tailwind.config.js`:
+    ```js
+    const { execSync } = require('child_process');
+    let locoBundlePath =
+      execSync('bundle show loco_motion-rails').toString().trim();
+
+    module.exports = {
+      content: [
+        `${locoBundlePath}/app/components/**/*.{rb,js,html,haml}`,
+        'app/components/**/*.{rb,js,html,haml}',
+        'app/views/**/*.{rb,js,html,haml}',
+      ]
+    }
+    ```
+  - Add a note that plugins (DaisyUI, Typography) must be declared in the
+    CSS file via `@plugin`, not in `tailwind.config.js`.
+- Update the `> [!WARNING]` note about `bundle show` to reference
+  `loco_motion-rails`.
+- Remove the stale CAUTION callout that says the components are "NOT ready
+  for production / public use" if it no longer applies, or update it to
+  reflect the current state of the library.
+
+### 5. (Optional) Add application.tailwind.css Example
+
+**Purpose**: Give new users a concrete starting point for the CSS file,
+especially since there is no existing documentation for the CSS-first
+approach.
+
+**File to Edit**: `README.md`
+
+**Changes to Make**:
+
+- After the DaisyUI `@plugin` block, add a collapsible or inline example
+  showing a complete minimal `application.tailwind.css`:
+  ```css
+  /* Import the base Tailwind theme */
+  @import 'tailwindcss';
+
+  /* Include DaisyUI and optionally Typography */
+  @plugin '@tailwindcss/typography';
+  @plugin 'daisyui' {
+    themes: light --default, dark --prefersdark;
+  }
+
+  /* Point to tailwind.config.js for content scan paths */
+  @config "../tailwind.config.js";
+  ```
+
+### 6. Verification
+
+**Purpose**: Confirm the README renders correctly and all links work.
+
+**Steps**:
+
+- Preview the README in GitHub or a Markdown renderer to confirm headers,
+  code blocks, and callouts render as expected.
+- Verify the TOC links still resolve correctly (especially if section
+  headings changed).
+- Do a final pass grepping for any remaining `0.4.0`, `loco_motion` (bare,
+  without `-rails`), or `tailwind.config.js plugins` references that may
+  have been missed:
+  ```bash
+  grep -n "0\.4\.0\|bundle show loco_motion[^-]\|plugins.*daisyui\|require.*daisyui" README.md
+  ```
+
+**Expected Results**:
+
+- No references to the Tailwind 3 DaisyUI plugin approach remain.
+- All `bundle show` commands reference `loco_motion-rails`.
+- The DISCLAIMER section is gone or accurately describes the current state.
+- The gem version in the install example is `~> 0.5.2`.
+- The `tailwind.config.js` snippet shows content paths only (no plugins).


### PR DESCRIPTION
## Context

The README install documentation was written for Tailwind 3 / DaisyUI 4 and contains several outdated or incorrect instructions that confuse new users upgrading to v0.5.x (which ships Tailwind 4 and DaisyUI 5).

## Related Issues

Fixes #106

## Type of Change

- [x] Documentation update

## Description

This PR updates the README to reflect the current Tailwind 4 / DaisyUI 5 setup process:

### Changes Made

1. **Replaced DISCLAIMER section** with a brief "Current Status" note stating that v0.5.x ships with Tailwind 4 and DaisyUI 5, and the install approach has changed.

2. **Rewrote "Install DaisyUI" section** to document the CSS-first approach:
   - Updated install command to `yarn add tailwindcss @tailwindcss/cli daisyui` (no `--dev`, no `@latest`)
   - Removed the `tailwind.config.js` plugin approach entirely
   - Added example CSS file showing `@import 'tailwindcss'` and `@plugin 'daisyui'` directives
   - Clarified that `tailwind.config.js` is now content-only (no plugins)

3. **Updated LocoMotion Install section**:
   - Changed gem version from `0.4.0` to `~> 0.5.2`
   - Removed stale GitHub source line; now points to RubyGems
   - Fixed `bundle show loco_motion` → `bundle show loco_motion-rails`
   - Updated `tailwind.config.js` snippet to show content-only config matching the demo app
   - Added note that plugins must be declared in CSS file, not `tailwind.config.js`
   - Updated CAUTION callout to reflect current development status

4. **Updated supporting notes** to clarify that Tailwind 4 moves plugin configuration into the CSS file.

### Files Modified

- `README.md` — Updated install instructions, removed outdated DISCLAIMER, added CSS-first examples
- `docs/plans/202605-2-update-readme-install-docs.md` — Implementation plan (reference document)

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have reviewed my own code for potential improvements

## Additional Notes

The changes align with the working setup in `docs/demo/app/assets/stylesheets/application.tailwind.css` and `docs/demo/tailwind.config.js`, ensuring the README examples match the actual demo app configuration.

https://claude.ai/code/session_014kb9gaaVHB6oZWEmXsMuQJ