### PR TITLE
Add missing page titles to docs and guide pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ releases** should be considered **breaking**!
 
 ### Demo / Docs Changes
 
+- add(Docs): Add missing page titles to Install, LLMs, Docker, HAML, and Debugging pages
 - feat(Join): Update join examples to use `with_button` slot instead of `with_item` for buttons
 - feat(Join): Add expansive direct content example with input, select, and indicator components
 - feat(RadioButton): Add radio buttons with labels examples to demo

--- a/docs/demo/app/views/docs/02_install.html.haml
+++ b/docs/demo/app/views/docs/02_install.html.haml
@@ -1,3 +1,6 @@
+= content_for(:page_title) do
+  Install
+
 .max-w-prose
   = doc_info(url: "https://rubyonrails.org", image_path: "logos/rails.svg", image_alt: "Rails Logo") do
     :markdown

--- a/docs/demo/app/views/docs/03_llms.html.haml
+++ b/docs/demo/app/views/docs/03_llms.html.haml
@@ -1,3 +1,6 @@
+= content_for(:page_title) do
+  LLMs
+
 .max-w-prose
   = doc_info(url: "/llms-v#{LocoMotion::VERSION}.txt", image_path: "logos/openai.svg", image_alt: "OpenAI Logo") do
     :markdown

--- a/docs/demo/app/views/guides/01_docker.html.haml
+++ b/docs/demo/app/views/guides/01_docker.html.haml
@@ -1,3 +1,6 @@
+= content_for(:page_title) do
+  Docker
+
 = render "wip_warning"
 
 .max-w-prose

--- a/docs/demo/app/views/guides/02_haml.html.haml
+++ b/docs/demo/app/views/guides/02_haml.html.haml
@@ -1,3 +1,6 @@
+= content_for(:page_title) do
+  HAML
+
 = render "wip_warning"
 
 .max-w-prose

--- a/docs/demo/app/views/guides/03_debugging.html.haml
+++ b/docs/demo/app/views/guides/03_debugging.html.haml
@@ -1,3 +1,6 @@
+= content_for(:page_title) do
+  Debugging
+
 = render "wip_warning"
 
 .max-w-prose


### PR DESCRIPTION
## Context

Several standalone doc and guide pages were missing <code>content_for(:page_title)</code>, leaving the browser tab title blank when visiting those pages. All example pages get this automatically via <code>DocTitleComponent</code>, but doc/guide pages that don't use <code>doc_title</code> need it set explicitly.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Added <code>content_for(:page_title)</code> to <code>docs/02_install.html.haml</code> ("Install")
- Added <code>content_for(:page_title)</code> to <code>docs/03_llms.html.haml</code> ("LLMs")
- Added <code>content_for(:page_title)</code> to <code>guides/01_docker.html.haml</code> ("Docker")
- Added <code>content_for(:page_title)</code> to <code>guides/02_haml.html.haml</code> ("HAML")
- Added <code>content_for(:page_title)</code> to <code>guides/03_debugging.html.haml</code> ("Debugging")

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

N/A