### PR TITLE
feat(DataInput): Add ergonomic aria/data attribute API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ releases** should be considered **breaking**!
 
 ### Components Changes
 
+- feat(DataInput): Add `AriableComponent` concern to Checkbox, Toggle, RadioButton, TextInput, TextArea, Select, Range, and FileInput that automatically sets `aria-required="true"` when `required: true` is passed (unless the user provides `aria-required` explicitly)
 - feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks
 - feat(Checkbox): Add label examples for start/end labels and custom content blocks
 - feat(Join): Add automatic `join-item` CSS class injection for items slot using `BasicComponent.build(css: "join-item")`
@@ -43,6 +44,8 @@ releases** should be considered **breaking**!
 - chore(Skills): Split `start-issue` into two focused skills: `create-issue`
   (investigate → draft → post a GitHub issue) and `start-issue` (read an
   existing issue, propose a branch, optionally plan)
+- feat(BaseComponent): Add universal `aria:` / `data:` shorthands (and per-part `{part}_aria` / `{part}_data`) that deep-merge into a part's HTML, so `aria: { label: "Save" }` renders `aria-label="Save"` without nesting inside `html:`
+- feat(ComponentConfig): Add `add_aria` / `add_data` author helpers (delegated from `BaseComponent`) for setting default `aria-*` / `data-*` attributes on a part
 - feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
 - feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
 - feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern

--- a/app/components/daisy/data_input/checkbox_component.rb
+++ b/app/components/daisy/data_input/checkbox_component.rb
@@ -44,6 +44,7 @@
 #
 class Daisy::DataInput::CheckboxComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LabelableComponent
+  include LocoMotion::Concerns::AriableComponent
 
   attr_reader :name, :id, :value, :checked, :toggle, :disabled, :required
 

--- a/app/components/daisy/data_input/file_input_component.rb
+++ b/app/components/daisy/data_input/file_input_component.rb
@@ -24,6 +24,8 @@
 #   = daisy_file_input(name: "document", id: "document", disabled: true)
 #
 class Daisy::DataInput::FileInputComponent < LocoMotion::BaseComponent
+  include LocoMotion::Concerns::AriableComponent
+
   attr_reader :name, :id, :accept, :multiple, :disabled, :required
 
   #
@@ -62,6 +64,8 @@ class Daisy::DataInput::FileInputComponent < LocoMotion::BaseComponent
   # Calls the {setup_component} method before rendering the component.
   #
   def before_render
+    super
+
     setup_component
   end
 

--- a/app/components/daisy/data_input/filter_component.rb
+++ b/app/components/daisy/data_input/filter_component.rb
@@ -69,9 +69,7 @@ module Daisy
           add_html(:component, { id: @id })
 
           # Add aria-label if specified
-          if @label.present?
-            add_html(:component, { "aria-label": @label })
-          end
+          add_aria(:component, label: @label) if @label.present?
         end
       end
 

--- a/app/components/daisy/data_input/radio_button_component.rb
+++ b/app/components/daisy/data_input/radio_button_component.rb
@@ -42,6 +42,7 @@
 #
 class Daisy::DataInput::RadioButtonComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LabelableComponent
+  include LocoMotion::Concerns::AriableComponent
 
   set_component_name :radio
 

--- a/app/components/daisy/data_input/range_component.rb
+++ b/app/components/daisy/data_input/range_component.rb
@@ -16,6 +16,8 @@
 #   = daisy_range(name: "error_range", id: "error_range", css: "range-error")
 #
 class Daisy::DataInput::RangeComponent < LocoMotion::BaseComponent
+  include LocoMotion::Concerns::AriableComponent
+
   attr_reader :name, :id, :min, :max, :step, :value, :disabled, :required
 
   #
@@ -58,6 +60,8 @@ class Daisy::DataInput::RangeComponent < LocoMotion::BaseComponent
   # Calls the {setup_component} method before rendering the component.
   #
   def before_render
+    super
+
     setup_component
   end
 

--- a/app/components/daisy/data_input/rating_component.rb
+++ b/app/components/daisy/data_input/rating_component.rb
@@ -122,13 +122,13 @@ class Daisy::DataInput::RatingComponent < LocoMotion::BaseComponent
       input_attrs = {
         loco_parent: component_ref,
         css: ["where:mask where:mask-star", @inputs_css].compact.join(" "),
+        aria: { label: "#{rating} star" },
         html: {
           name: @name,
           value: rating,
           checked: @value == rating,
           required: @required && rating == 1,
           disabled: @disabled,
-          "aria-label": "#{rating} star",
           **@inputs_html
         }
       }

--- a/app/components/daisy/data_input/select_component.rb
+++ b/app/components/daisy/data_input/select_component.rb
@@ -41,6 +41,7 @@
 #
 class Daisy::DataInput::SelectComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LabelableComponent
+  include LocoMotion::Concerns::AriableComponent
 
   class SelectOptionComponent < LocoMotion::BasicComponent
     attr_reader :value, :label, :selected, :disabled

--- a/app/components/daisy/data_input/text_area_component.rb
+++ b/app/components/daisy/data_input/text_area_component.rb
@@ -41,6 +41,8 @@
 #   = daisy_text_area(name: "message", readonly: true, value: "This content cannot be edited.")
 #
 class Daisy::DataInput::TextAreaComponent < LocoMotion::BaseComponent
+  include LocoMotion::Concerns::AriableComponent
+
   attr_reader :name, :id, :value, :placeholder, :rows, :cols, :disabled, :required, :readonly
 
   #
@@ -87,6 +89,8 @@ class Daisy::DataInput::TextAreaComponent < LocoMotion::BaseComponent
   # Calls the {setup_component} method before rendering the component.
   #
   def before_render
+    super
+
     setup_component
   end
 

--- a/app/components/daisy/data_input/text_input_component.rb
+++ b/app/components/daisy/data_input/text_input_component.rb
@@ -59,6 +59,7 @@
 #
 class Daisy::DataInput::TextInputComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LabelableComponent
+  include LocoMotion::Concerns::AriableComponent
 
   attr_reader :name, :id, :value, :type, :disabled, :required, :readonly
 

--- a/app/components/daisy/layout/drawer_component.rb
+++ b/app/components/daisy/layout/drawer_component.rb
@@ -150,6 +150,7 @@ class Daisy::Layout::DrawerComponent < LocoMotion::BaseComponent
   def setup_overlay
     set_tag_name(:overlay, :label)
     add_css(:overlay, "drawer-overlay")
-    add_html(:overlay, { for: @id, "aria-label": "close sidebar" })
+    add_html(:overlay, { for: @id })
+    add_aria(:overlay, label: "close sidebar")
   end
 end

--- a/app/components/daisy/navigation/tabs_component.rb
+++ b/app/components/daisy/navigation/tabs_component.rb
@@ -137,7 +137,8 @@ class Daisy::Navigation::TabsComponent < LocoMotion::BaseComponent
       set_tag_name(:component, :a)
       add_css(:component, "tab")
       add_css(:component, "tab-active") if @active || @checked
-      add_html(:component, { role: "tab", href: @href, target: @target, "aria-label": @simple_title })
+      add_html(:component, { role: "tab", href: @href, target: @target })
+      add_aria(:component, label: @simple_title)
       add_html(:component, { disabled: @disabled }) if @disabled
     end
 
@@ -147,11 +148,11 @@ class Daisy::Navigation::TabsComponent < LocoMotion::BaseComponent
       add_html(:component, {
         type: "radio",
         role: "tab",
-        "aria-label": @simple_title,
         name: @name,
         value: @value,
         checked: @active || @checked
       })
+      add_aria(:component, label: @simple_title)
       add_html(:component, { disabled: @disabled }) if @disabled
     end
 

--- a/docs/demo/app/views/examples/daisy/data_input/text_inputs.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/text_inputs.html.haml
@@ -193,3 +193,28 @@
 
       = form.daisy_label(:password, css: "mt-4")
       = form.daisy_text_input(:password, type: "password")
+
+
+= doc_example(title: "Accessibility & ARIA Attributes") do |doc|
+  - doc.with_description do
+    :markdown
+      Every component accepts an `aria:` shorthand so you don't have to nest
+      attributes inside `html:` or hand-dasherize keys. Each key becomes an
+      `aria-*` attribute, so `aria: { describedby: "pw-help" }` renders
+      `aria-describedby="pw-help"`. A matching `data:` shorthand works the
+      same way for `data-*` attributes.
+
+    = doc_note(modifier: :tip, css: "mb-8") do
+      :markdown
+        Input components automatically add `aria-required="true"` when you pass
+        `required: true`, so you only need to set ARIA attributes that can't be
+        derived (like `aria-describedby` or `aria-label` on an unlabeled
+        input).
+
+  .flex.flex-col.gap-2
+    = daisy_label(for: "aria_password", title: "Password")
+    = daisy_text_input(name: "aria_password", id: "aria_password",
+      type: "password", required: true,
+      aria: { describedby: "aria_password_help" })
+    %span#aria_password_help.text-sm.opacity-70
+      Must be at least 12 characters.

--- a/lib/loco_motion/base_component.rb
+++ b/lib/loco_motion/base_component.rb
@@ -24,11 +24,35 @@ class LocoMotion::BaseComponent < ViewComponent::Base
   #
   # Allow users to alter the config through the component itself
   #
-  delegate :set_tag_name, :add_css, :add_html, :add_stimulus_controller, :modifiers,
+  delegate :set_tag_name, :add_css, :add_html, :add_aria, :add_data,
+    :add_stimulus_controller, :modifiers,
     to: :config
 
   #
   # Create a new instance of a component.
+  #
+  # All components accept the following universal options for customizing the
+  # rendered HTML. Each is also available in a part-specific form by prefixing
+  # it with the part name (e.g. `title_css`, `overlay_html`, `wrapper_aria`).
+  #
+  # @option kws [String] :css Extra CSS classes for the component's main
+  #   element.
+  #
+  # @option kws [Hash] :html Extra HTML attributes for the component's main
+  #   element. Supports nested `aria:` / `data:` hashes, so
+  #   `html: { aria: { label: "Save" } }` renders `aria-label="Save"`.
+  #
+  # @option kws [Hash] :aria A shorthand for `html: { aria: { ... } }`. Each
+  #   key becomes an `aria-*` attribute, so `aria: { label: "Save" }` renders
+  #   `aria-label="Save"`. Values deep-merge with (and are overridden by
+  #   nothing except) any aria set by the component itself.
+  #
+  # @option kws [Hash] :data A shorthand for `html: { data: { ... } }`. Each
+  #   key becomes a `data-*` attribute, so `data: { foo: "bar" }` renders
+  #   `data-foo="bar"`.
+  #
+  # @option kws [Symbol] :tag_name Override the HTML tag for the component's
+  #   main element.
   #
   def initialize(*args, **kws, &block)
     super

--- a/lib/loco_motion/component_config.rb
+++ b/lib/loco_motion/component_config.rb
@@ -27,6 +27,14 @@ class LocoMotion::ComponentConfig
         user_tag_name: @options["#{part}_tag_name".to_sym],
         user_stimulus_controllers: @options["#{part}_controllers".to_sym] || [],
       }
+
+      # Allow users to pass `{part}_aria` / `{part}_data` as a shorthand for
+      # nesting `aria:` / `data:` hashes inside `{part}_html`.
+      part_aria = @options["#{part}_aria".to_sym]
+      part_data = @options["#{part}_data".to_sym]
+
+      @parts[part][:user_html] = @parts[part][:user_html].deep_merge(aria: part_aria) if part_aria
+      @parts[part][:user_html] = @parts[part][:user_html].deep_merge(data: part_data) if part_data
     end
 
     # Allow useres to pass some shortened attributes for the component part
@@ -40,6 +48,8 @@ class LocoMotion::ComponentConfig
     @parts[:component][:user_tag_name] = kws[:tag_name] if kws[:tag_name]
     @parts[:component][:user_css].push(kws[:css]) if kws[:css]
     @parts[:component][:user_html].deep_merge!(kws[:html]) if kws[:html]
+    @parts[:component][:user_html].deep_merge!(aria: kws[:aria]) if kws[:aria]
+    @parts[:component][:user_html].deep_merge!(data: kws[:data]) if kws[:data]
     @parts[:component][:user_stimulus_controllers].push(kws[:controller]) if kws[:controller]
     @parts[:component][:user_stimulus_controllers].push(kws[:controllers]) if kws[:controllers]
   end
@@ -56,6 +66,8 @@ class LocoMotion::ComponentConfig
       set_tag_name(part, kws["#{part}_tag_name".to_sym])
       add_css(part, kws["#{part}_css".to_sym])
       add_html(part, kws["#{part}_html".to_sym])
+      add_aria(part, kws["#{part}_aria".to_sym])
+      add_data(part, kws["#{part}_data".to_sym])
 
       controllers = kws["#{part}_controllers".to_sym] || []
 
@@ -95,6 +107,26 @@ class LocoMotion::ComponentConfig
   #
   def add_html(part_name, html)
     @parts[part_name][:default_html] = @parts[part_name][:default_html].deep_merge(html) if html
+  end
+
+  #
+  # Adds default `aria-*` attributes to the requested component part. This is a
+  # convenience wrapper around {add_html} that nests the given hash under the
+  # `aria:` key, so `add_aria(:component, label: "Save")` renders
+  # `aria-label="Save"`.
+  #
+  def add_aria(part_name, aria)
+    add_html(part_name, { aria: aria }) if aria
+  end
+
+  #
+  # Adds default `data-*` attributes to the requested component part. This is a
+  # convenience wrapper around {add_html} that nests the given hash under the
+  # `data:` key, so `add_data(:component, foo: "bar")` renders
+  # `data-foo="bar"`.
+  #
+  def add_data(part_name, data)
+    add_html(part_name, { data: data }) if data
   end
 
   #

--- a/lib/loco_motion/concerns/ariable_component.rb
+++ b/lib/loco_motion/concerns/ariable_component.rb
@@ -1,0 +1,77 @@
+require "active_support/concern"
+
+module LocoMotion
+  module Concerns
+    #
+    # The AriableComponent concern wires up sensible default `aria-*`
+    # attributes for components (primarily form inputs) so that authors and
+    # users don't have to set them by hand.
+    #
+    # It is intentionally conservative: native HTML controls already expose
+    # most of their semantics (checked, disabled, required, etc.) to assistive
+    # technology, so this concern only fills in attributes that are commonly
+    # expected and never overrides anything the user passed explicitly via the
+    # `aria:` shortcut or `*_html` options.
+    #
+    # **Current behavior**
+    #
+    # - When the component's `required` option is truthy, adds
+    #   `aria-required="true"` (unless the user already set `aria-required`).
+    #
+    # Users can always set or override any `aria-*` attribute using the `aria:`
+    # shortcut, e.g. `daisy_text_input(aria: { describedby: "email-help" })`.
+    #
+    # @loco_example Including the concern in a component
+    #   class MyInputComponent < LocoMotion::BaseComponent
+    #     include LocoMotion::Concerns::AriableComponent
+    #     # component implementation ...
+    #   end
+    #
+    module AriableComponent
+      extend ActiveSupport::Concern
+
+      included do |base|
+        base.register_component_setup(:_setup_ariable_component)
+      end
+
+      protected
+
+      #
+      # Applies the default `aria-*` attributes for the component. Called
+      # automatically during the render lifecycle.
+      #
+      def _setup_ariable_component
+        _setup_ariable_required
+      end
+
+      #
+      # Mirrors a truthy `required` option as `aria-required="true"` unless the
+      # user explicitly provided an `aria-required` value.
+      #
+      def _setup_ariable_required
+        return unless config_option(:required)
+        return if _ariable_user_set?(:required)
+
+        add_aria(:component, required: true)
+      end
+
+      #
+      # Determines whether the user explicitly supplied an `aria-{key}`
+      # attribute for the component part, in either the nested
+      # (`aria: { key: ... }`) or dasherized (`"aria-key"`) form, so we avoid
+      # overriding their intent or rendering duplicate attributes.
+      #
+      # @param key [Symbol] The aria attribute name without the `aria-` prefix.
+      #
+      # @return [Boolean]
+      #
+      def _ariable_user_set?(key)
+        user_html = config.get_part(:component)[:user_html] || {}
+        nested = user_html[:aria] || user_html["aria"] || {}
+
+        nested.key?(key) || nested.key?(key.to_s) ||
+          user_html.key?(:"aria-#{key}") || user_html.key?("aria-#{key}")
+      end
+    end
+  end
+end

--- a/spec/lib/loco_motion/component_config_spec.rb
+++ b/spec/lib/loco_motion/component_config_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe LocoMotion::ComponentConfig, type: :component do
+  # A component with an extra part so we can exercise per-part shortcuts.
+  class AriaConfigComponent < LocoMotion::BaseComponent
+    define_part :inner
+
+    def call
+      part(:component) do
+        part(:inner) { "Inner" }
+      end
+    end
+  end
+
+  # A component that sets default aria/data via the author helpers.
+  class AuthorAriaComponent < LocoMotion::BaseComponent
+    def call
+      part(:component) { "Content" }
+    end
+
+    def before_render
+      super
+
+      add_aria(:component, label: "Author Label")
+      add_data(:component, role: "widget")
+    end
+  end
+
+  describe "user-facing aria: shortcut" do
+    it "renders top-level aria as aria-* on the component part" do
+      render_inline(AriaConfigComponent.new(aria: { label: "Save", pressed: true }))
+
+      expect(page).to have_css("div[aria-label='Save'][aria-pressed='true']")
+    end
+
+    it "renders per-part {part}_aria on the matching part" do
+      render_inline(AriaConfigComponent.new(inner_aria: { hidden: true }))
+
+      expect(page).to have_css("div[aria-hidden='true']", text: "Inner")
+    end
+  end
+
+  describe "user-facing data: shortcut" do
+    it "renders top-level data as data-* on the component part" do
+      render_inline(AriaConfigComponent.new(data: { foo: "bar" }))
+
+      expect(page).to have_css("div[data-foo='bar']")
+    end
+
+    it "renders per-part {part}_data on the matching part" do
+      render_inline(AriaConfigComponent.new(inner_data: { baz: "qux" }))
+
+      expect(page).to have_css("div[data-baz='qux']", text: "Inner")
+    end
+  end
+
+  describe "author helpers" do
+    it "renders defaults added via add_aria and add_data" do
+      render_inline(AuthorAriaComponent.new)
+
+      expect(page).to have_css("div[aria-label='Author Label'][data-role='widget']")
+    end
+
+    it "lets the user override an author default via the aria: shortcut" do
+      render_inline(AuthorAriaComponent.new(aria: { label: "User Label" }))
+
+      expect(page).to have_css("div[aria-label='User Label']")
+    end
+  end
+end

--- a/spec/lib/loco_motion/concerns/ariable_component_spec.rb
+++ b/spec/lib/loco_motion/concerns/ariable_component_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+# Test class that includes the concern and exposes a `required` option, just
+# like the real input components do.
+class AriableTestComponent < LocoMotion::BaseComponent
+  include LocoMotion::Concerns::AriableComponent
+
+  def initialize(**kws)
+    super
+    @required = config_option(:required, false)
+  end
+
+  def call
+    part(:component) { "Test Content" }
+  end
+
+  def before_render
+    super
+
+    set_tag_name(:component, :input)
+  end
+end
+
+RSpec.describe LocoMotion::Concerns::AriableComponent, type: :component do
+  context "when required is true" do
+    it "adds aria-required" do
+      render_inline(AriableTestComponent.new(required: true))
+
+      expect(page).to have_css("input[aria-required='true']")
+    end
+  end
+
+  context "when required is false or omitted" do
+    it "does not add aria-required" do
+      render_inline(AriableTestComponent.new)
+
+      expect(page).not_to have_css("input[aria-required]")
+    end
+  end
+
+  context "when the user provides aria-required explicitly" do
+    it "does not override the nested aria form" do
+      render_inline(AriableTestComponent.new(required: true, aria: { required: false }))
+
+      expect(page).to have_css("input[aria-required='false']")
+    end
+
+    it "does not override the dasherized html form" do
+      render_inline(AriableTestComponent.new(required: true, html: { "aria-required": "false" }))
+
+      expect(page).to have_css("input[aria-required='false']")
+      expect(page).not_to have_css("input[aria-required='true']")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Setting `aria-*` (and `data-*`) attributes previously required hand-dasherizing
keys and nesting them inside `html: { "aria-label": "..." }` on every input.
This adds a first-class, ergonomic API for ARIA/data attributes that works
across all components, plus a small set of safe smart defaults for form inputs.

## Related Issues

N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test update/addition

## Description

**User-facing shortcuts** (`ComponentConfig`)
- Universal `aria:` / `data:` options plus per-part `{part}_aria` /
  `{part}_data`, deep-merged into the part's HTML. `aria: { label: "Save" }`
  renders `aria-label="Save"`. Works on every component automatically.

**Author helpers**
- `add_aria` / `add_data` (delegated from `BaseComponent`) for setting default
  `aria-*` / `data-*` attributes from within component code. Existing manual
  `"aria-label":` usages in Tabs, Filter, Rating, and Drawer were refactored to
  use them.

**Smart defaults** — new `LocoMotion::Concerns::AriableComponent`
- Auto-sets `aria-required="true"` when `required: true` (guarded so an explicit
  user `aria-required` always wins). Included in Checkbox, Toggle, RadioButton,
  TextInput, TextArea, Select, Range, and FileInput.
- Added missing `super` to `before_render` in Range/FileInput/TextArea so
  registered concern setups run.

> Note: auto `aria-label` from a visible label was intentionally **not** added —
> the templates render inputs inside the `<label>`, so the accessible name is
> already provided and an injected `aria-label` would be redundant.

**Docs**
- YARD `@option` docs for the universal `css`/`html`/`aria`/`data`/`tag_name`
  options on `BaseComponent#initialize`, plus full docs on the concern/helpers.
- New "Accessibility & ARIA Attributes" example on the Text Inputs demo page.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Full library suite passes (1144 examples, 0 failures). Verified in-browser that
the Text Inputs demo page renders `aria-required="true"` and `aria-describedby`,
and all affected demo pages return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)