### PR TITLE
fix(ThemeController): Auto-sync theme across all selectors

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -89,10 +89,10 @@ head -20 CHANGELOG.md
 - If it exists, append new bullet items to the bottom of that section.
 - If it does not exist, create the section header and add items beneath it.
 
-Wrap every entry at 80 characters (continuation lines indented to align with
+Wrap every entry at 110 characters (continuation lines indented to align with
 the text after the `- ` marker). Never split an inline code span, Markdown
 link, or `<code>` tag across lines — only those unbreakable tokens may push a
-line past 80. See the `update-changelog` skill for the full rules.
+line past 110. See the `update-changelog` skill for the full rules.
 
 Follow the categorization rules:
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -89,6 +89,11 @@ head -20 CHANGELOG.md
 - If it exists, append new bullet items to the bottom of that section.
 - If it does not exist, create the section header and add items beneath it.
 
+Wrap every entry at 80 characters (continuation lines indented to align with
+the text after the `- ` marker). Never split an inline code span, Markdown
+link, or `<code>` tag across lines — only those unbreakable tokens may push a
+line past 80. See the `update-changelog` skill for the full rules.
+
 Follow the categorization rules:
 
 | Change type | CHANGELOG section |

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -72,7 +72,14 @@ Rules:
 - Never delete or alter existing entries.
 - Append new items to the **bottom** of the relevant subsection.
 - Use sentence case for entry text and end with a period.
-- Wrap lines at 80 characters.
+- Wrap all entry descriptions at 80 characters. Indent continuation lines to
+  align with the text after the marker (2 spaces under a top-level `- ` item,
+  4 spaces under a nested `  - ` item).
+- Never break inside an inline code span (`` `...` ``), a Markdown link
+  (`[text](url)`), or a `<code>...</code>` tag — keep each on one line. A line
+  may exceed 80 characters only when a single one of these unbreakable tokens
+  is itself longer than the remaining space (code/links are allowed to run
+  long; prose is not).
 
 ### Step 6: Create the `[Unreleased]` section if missing
 

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -72,12 +72,12 @@ Rules:
 - Never delete or alter existing entries.
 - Append new items to the **bottom** of the relevant subsection.
 - Use sentence case for entry text and end with a period.
-- Wrap all entry descriptions at 80 characters. Indent continuation lines to
+- Wrap all entry descriptions at 110 characters. Indent continuation lines to
   align with the text after the marker (2 spaces under a top-level `- ` item,
   4 spaces under a nested `  - ` item).
 - Never break inside an inline code span (`` `...` ``), a Markdown link
   (`[text](url)`), or a `<code>...</code>` tag — keep each on one line. A line
-  may exceed 80 characters only when a single one of these unbreakable tokens
+  may exceed 110 characters only when a single one of these unbreakable tokens
   is itself longer than the remaining space (code/links are allowed to run
   long; prose is not).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,215 +2,162 @@
 
 All notable changes to LocoMotion will be documented in this file.
 
-The format is loosely based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 _mostly_ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-We say mostly because all versions before 1.0.0 will likely have breaking
-changes as we don't consider the project "released" until that point in time.
+We say mostly because all versions before 1.0.0 will likely have breaking changes as we don't consider the
+project "released" until that point in time.
 
-We plan to use patch versions only for bug fixes, and for now, all **minor
-releases** should be considered **breaking**!
+We plan to use patch versions only for bug fixes, and for now, all **minor releases** should be considered
+**breaking**!
 
 ## [Unreleased]
 
 ### Components Changes
 
-- fix(Theme): Add `theme_preload_script` helper to prevent flash of content when
-  loading with non-default theme
-  ([Fixes #49](https://github.com/profoundry-us/loco_motion/issues/49))
-- fix(Theme): Update `clearTheme` method to remove `data-theme` attribute from
-  document element, preventing need for page refresh when clearing theme
+- fix(Theme): Add `theme_preload_script` helper to prevent flash of content when loading with non-default
+  theme ([Fixes #49](https://github.com/profoundry-us/loco_motion/issues/49))
+- fix(Theme): Update `clearTheme` method to remove `data-theme` attribute from document element, preventing
+  need for page refresh when clearing theme
 
-- feat(DataInput): Add `AriableComponent` concern to Checkbox, Toggle,
-  RadioButton, TextInput, TextArea, Select, Range, and FileInput that
-  automatically sets `aria-required="true"` when `required: true` is passed
+- feat(DataInput): Add `AriableComponent` concern to Checkbox, Toggle, RadioButton, TextInput, TextArea,
+  Select, Range, and FileInput that automatically sets `aria-required="true"` when `required: true` is passed
   (unless the user provides `aria-required` explicitly)
-- feat(RadioButton): Add LabelableComponent concern with start/end label support
-  and custom content blocks
-- feat(Checkbox): Add label examples for start/end labels and custom content
-  blocks
+- feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks
+- feat(Checkbox): Add label examples for start/end labels and custom content blocks
 - feat(Join): Add automatic `join-item` CSS class injection for items slot using
   `BasicComponent.build(css: "join-item")`
-- feat(Join): Add `buttons` slot using `ButtonComponent.build(css: "join-item")`
+- feat(Join): Add `buttons` slot using `ButtonComponent.build(css: "join-item")` for automatic CSS class
+  injection
+- feat(Join): Add `radios` slot using `RadioButtonComponent.build(skip_styling: true, css: "join-item btn")`
   for automatic CSS class injection
-- feat(Join): Add `radios` slot using
-  `RadioButtonComponent.build(skip_styling: true, css: "join-item btn")` for
-  automatic CSS class injection
-- feat(Join): Update call method to handle items, buttons, radios, or direct
-  content
-- fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES`
-  constant so `diff-item-1` / `diff-item-2` are detected as string literals by
-  Tailwind v4's Ruby extractor
+- feat(Join): Update call method to handle items, buttons, radios, or direct content
+- fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES` constant so `diff-item-1` /
+  `diff-item-2` are detected as string literals by Tailwind v4's Ruby extractor
   ([Fixes #82](https://github.com/profoundry-us/loco_motion/issues/82))
-- add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping
-  DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D
-  cards via `LinkableComponent`
+- add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect,
+  with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent`
   ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
-- feat(HoverGallery): Add new `Daisy::Layout::HoverGalleryComponent`
-  (`daisy_hover_gallery`) with slot-based `with_image` API, `srcs:` convenience
-  shorthand, content fallback for custom block markup, and demo examples
+- feat(HoverGallery): Add new `Daisy::Layout::HoverGalleryComponent` (`daisy_hover_gallery`) with slot-based
+  `with_image` API, `srcs:` convenience shorthand, content fallback for custom block markup, and demo examples
   ([Fixes #96](https://github.com/profoundry-us/loco_motion/issues/96))
-- fix(HoverGallery): Replace non-existent `set_tag` with `set_tag_name` in
-  `setup_component`, and move `ImageComponent` tag assignment from `initialize`
-  to `before_render` via `set_tag_name(:component, :img)`
-- fix(Avatar): Suppress `where:bg-neutral` default on placeholder wrapper when
-  `skeleton` is in `wrapper_css`, preventing the neutral background from
-  bleeding through the skeleton shimmer gradient
+- fix(HoverGallery): Replace non-existent `set_tag` with `set_tag_name` in `setup_component`, and move
+  `ImageComponent` tag assignment from `initialize` to `before_render` via `set_tag_name(:component, :img)`
+- fix(Avatar): Suppress `where:bg-neutral` default on placeholder wrapper when `skeleton` is in `wrapper_css`,
+  preventing the neutral background from bleeding through the skeleton shimmer gradient
   ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
-- fix(Skeleton): Standardize text-hiding in component skeleton examples
-  (`text-transparent` consistently); add `skeleton-text` example and docs for
-  DaisyUI 5's animated text shimmer class
+- fix(Skeleton): Standardize text-hiding in component skeleton examples (`text-transparent` consistently); add
+  `skeleton-text` example and docs for DaisyUI 5's animated text shimmer class
   ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
-- feat(DataDisplay): Add new `Daisy::DataDisplay::TextRotateComponent`
-  (`daisy_text_rotate`) with `ItemComponent` slot, `texts:` shorthand parameter,
-  a `wrapper` part (`wrapper_css:`) around the items, tooltip support, custom
-  block content (rendered after items), and per-item link (`href`) / icon
-  (`left_icon`/`right_icon`) support via `LinkableComponent` and
-  `IconableComponent`
+- feat(DataDisplay): Add new `Daisy::DataDisplay::TextRotateComponent` (`daisy_text_rotate`) with
+  `ItemComponent` slot, `texts:` shorthand parameter, a `wrapper` part (`wrapper_css:`) around the items,
+  tooltip support, custom block content (rendered after items), and per-item link (`href`) / icon
+  (`left_icon`/`right_icon`) support via `LinkableComponent` and `IconableComponent`
   ([Fixes #110](https://github.com/profoundry-us/loco_motion/issues/110))
-- feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to
-  `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent`
-  feature parity
+- feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent`
+  concern, matching `ButtonComponent` feature parity
   ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
-- feat(Navbar): Allow custom content to be passed directly inside the
-  component's block in addition to the existing `start`, `center`, and `end`
-  slots ([Fixes #83](https://github.com/profoundry-us/loco_motion/issues/83))
-- feat(Alert): Add auto-dismiss functionality with `autoclose` and `timeout`
-  parameters
-- feat(Alert): Add clickable link functionality with `href` and `target`
-  parameters
+- feat(Navbar): Allow custom content to be passed directly inside the component's block in addition to the
+  existing `start`, `center`, and `end` slots
+  ([Fixes #83](https://github.com/profoundry-us/loco_motion/issues/83))
+- feat(Alert): Add auto-dismiss functionality with `autoclose` and `timeout` parameters
+- feat(Alert): Add clickable link functionality with `href` and `target` parameters
 - feat(Alert): Add Stimulus action support with `action` parameter
-- feat(Alert): Add closable functionality with `closable` parameter and close
-  button
-- feat(Alert): Add AlertController to NPM package for client-side alert
-  management
+- feat(Alert): Add closable functionality with `closable` parameter and close button
+- feat(Alert): Add AlertController to NPM package for client-side alert management
 - feat(Configuration): Add comprehensive documentation to Configuration class
-- add(FAB): Add new `Daisy::Actions::FabComponent` (`daisy_fab`) implementing
-  the DaisyUI FAB / Speed Dial pattern with `button`, `activator`, and `action`
-  slots ([Fixes #93](https://github.com/profoundry-us/loco_motion/issues/93))
-- fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 by removing dead
-  `!mt-0` hack and moving sizing to the container via `css:` (override
-  `aspect-ratio`, `max-width`, `border-radius`) instead of `display_css`
+- add(FAB): Add new `Daisy::Actions::FabComponent` (`daisy_fab`) implementing the DaisyUI FAB / Speed Dial
+  pattern with `button`, `activator`, and `action` slots
+  ([Fixes #93](https://github.com/profoundry-us/loco_motion/issues/93))
+- fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 by removing dead `!mt-0` hack and moving sizing to
+  the container via `css:` (override `aspect-ratio`, `max-width`, `border-radius`) instead of `display_css`
   ([Fixes #99](https://github.com/profoundry-us/loco_motion/issues/99))
-- fix(Theme): Auto-sync the selected theme across every theme selector on the
-  page by watching `change` events and making `setInput` uncheck stale inputs,
-  so a selection in one switcher is no longer silently overridden by another;
-  radio inputs now persist to `localStorage` automatically with no `setTheme`
-  action wiring
+- fix(Theme): Auto-sync the selected theme across every theme selector on the page by watching `change` events
+  and making `setInput` uncheck stale inputs, so a selection in one switcher is no longer silently overridden
+  by another; radio inputs now persist to `localStorage` automatically with no `setTheme` action wiring
   ([Fixes #115](https://github.com/profoundry-us/loco_motion/issues/115))
-- fix(Theme): Namespace `build_radio_input` ids by input name
-  (`"#{name}-#{theme}"`) to avoid duplicate ids when multiple theme controllers
-  share a page
+- fix(Theme): Namespace `build_radio_input` ids by input name (`"#{name}-#{theme}"`) to avoid duplicate ids
+  when multiple theme controllers share a page
 
 ### General Changes
 
-- chore(Skills): Split `start-issue` into two focused skills: `create-issue`
-  (investigate → draft → post a GitHub issue) and `start-issue` (read an
-  existing issue, propose a branch, optionally plan)
-- feat(BaseComponent): Add universal `aria:` / `data:` shorthands (and per-part
-  `{part}_aria` / `{part}_data`) that deep-merge into a part's HTML, so
-  `aria: { label: "Save" }` renders `aria-label="Save"` without nesting inside
-  `html:`
-- feat(ComponentConfig): Add `add_aria` / `add_data` author helpers (delegated
-  from `BaseComponent`) for setting default `aria-*` / `data-*` attributes on a
-  part
-- feat(BaseComponent): Improve `build` method to merge build_kws into config
-  before initialize for proper precedence
-- feat(BaseComponent): Update instance variables for build_kws keys after
-  initialize to ensure options like `skip_styling` are available during
-  `setup_component`
-- feat(RadioButton): Move rendering from call method to HAML template to match
-  CheckboxComponent pattern
-- chore(justfile): Rename the `*-quick` targets (`all-quick`, `loco-quick`,
-  `demo-quick`, `yard-quick`) to `*-fast`
+- chore(Skills): Split `start-issue` into two focused skills: `create-issue` (investigate → draft → post a
+  GitHub issue) and `start-issue` (read an existing issue, propose a branch, optionally plan)
+- feat(BaseComponent): Add universal `aria:` / `data:` shorthands (and per-part `{part}_aria` / `{part}_data`)
+  that deep-merge into a part's HTML, so `aria: { label: "Save" }` renders `aria-label="Save"` without nesting
+  inside `html:`
+- feat(ComponentConfig): Add `add_aria` / `add_data` author helpers (delegated from `BaseComponent`) for
+  setting default `aria-*` / `data-*` attributes on a part
+- feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper
+  precedence
+- feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like
+  `skip_styling` are available during `setup_component`
+- feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern
+- chore(justfile): Rename the `*-quick` targets (`all-quick`, `loco-quick`, `demo-quick`, `yard-quick`) to
+  `*-fast`
 
 ### Demo / Docs Changes
 
-- fix(demo): Add `ads_preload_script` helper to prevent flash of ads content
-  when page loads
-- fix(demo): Move `ads_preload_script` after ads element in layout since it
-  needs to query for specific DOM elements
-- fix(demo): Add Playwright test to verify ads visibility is set correctly on
-  non-hidden pages
-- add(Docs): Add missing page titles to Install, LLMs, Docker, HAML, and
-  Debugging pages
-- feat(Join): Update join examples to use `with_button` slot instead of
-  `with_item` for buttons
-- feat(Join): Add expansive direct content example with input, select, and
-  indicator components
+- fix(demo): Add `ads_preload_script` helper to prevent flash of ads content when page loads
+- fix(demo): Move `ads_preload_script` after ads element in layout since it needs to query for specific DOM
+  elements
+- fix(demo): Add Playwright test to verify ads visibility is set correctly on non-hidden pages
+- add(Docs): Add missing page titles to Install, LLMs, Docker, HAML, and Debugging pages
+- feat(Join): Update join examples to use `with_button` slot instead of `with_item` for buttons
+- feat(Join): Add expansive direct content example with input, select, and indicator components
 - feat(RadioButton): Add radio buttons with labels examples to demo
-- add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image
-  gallery examples
-- add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in
-  network-restricted environments (e.g. Claude Code cloud) where OS package
-  repos are blocked; uses a multi-stage build to copy Node.js from
+- add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image gallery examples
+- add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in network-restricted environments (e.g.
+  Claude Code cloud) where OS package repos are blocked; uses a multi-stage build to copy Node.js from
   `node:20-slim` instead of installing via `nodesource`
-- add(Navbar): Add "Custom Content Navbar" example demonstrating block-based
-  custom content
-- feat(Alert): Add closable, auto-dismissing, clickable link, and Stimulus
-  action alert examples
+- add(Navbar): Add "Custom Content Navbar" example demonstrating block-based custom content
+- feat(Alert): Add closable, auto-dismissing, clickable link, and Stimulus action alert examples
 - feat(Alert): Add AlertDemoController for interactive click celebration demo
-- feat(Toast): Enhance Toast examples with closable, auto-dismiss, and clickable
-  features
+- feat(Toast): Enhance Toast examples with closable, auto-dismiss, and clickable features
 - feat(Toast): Add Toast positions example and reset functionality
 - docs(Toast): Update documentation to warn about AlertController dependency
 - docs(Alert): Update Alert examples with improved descriptions and formatting
-- add(FAB): Add FAB demo page with simple, speed dial, flower, and custom
-  activator examples
-- add(HoverGallery): Add Hover Galleries demo page with Basic, In a Card, and
-  Shorthand (`srcs:`) examples
-- add(TextRotate): Add Text Rotates demo page with examples for Basic usage,
-  `texts:` shorthand, Centered Items (`wrapper_css:`), Icons and Links (per-item
-  `icon`/`left_icon`/`right_icon` and `href`), Custom Content (custom block
-  markup with inline `daisy_avatar`s beside the text), Custom Duration
-  (3s/6s/10s), Inline in a Sentence, Different Font Sizes, and Custom Line
-  Height
-- docs(Skills): Add `run-demo` skill for booting the demo Rails app locally
-  without Docker, including Ruby/Node version handling, vendor symlink setup,
-  and the `file:../..` + `--no-lockfile` yarn pattern to avoid polluting
-  `yarn.lock`
-- docs(Skills): Add `screenshot-demo` skill for capturing full-page screenshots
-  and videos of demo pages via Playwright, depending on `run-demo`
-- docs(Skills): Update `create-pr` skill with label-selection guidance and a
-  follow-up `mcp__github__issue_write` step to apply labels after PR creation
-- docs(Theme): Update the Theme Controller "Theme Radio Inputs" example note to
-  document the automatic syncing, and link the preload-script note to the
-  `ThemeHelper` API docs
-- chore(demo): Switch the header version badge to a "View All Releases" tip
-  linking to the GitHub releases page, and remove the stale issue #49
-  flash-of-content comment
+- add(FAB): Add FAB demo page with simple, speed dial, flower, and custom activator examples
+- add(HoverGallery): Add Hover Galleries demo page with Basic, In a Card, and Shorthand (`srcs:`) examples
+- add(TextRotate): Add Text Rotates demo page with examples for Basic usage, `texts:` shorthand, Centered
+  Items (`wrapper_css:`), Icons and Links (per-item `icon`/`left_icon`/`right_icon` and `href`), Custom
+  Content (custom block markup with inline `daisy_avatar`s beside the text), Custom Duration (3s/6s/10s),
+  Inline in a Sentence, Different Font Sizes, and Custom Line Height
+- docs(Skills): Add `run-demo` skill for booting the demo Rails app locally without Docker, including
+  Ruby/Node version handling, vendor symlink setup, and the `file:../..` + `--no-lockfile` yarn pattern to
+  avoid polluting `yarn.lock`
+- docs(Skills): Add `screenshot-demo` skill for capturing full-page screenshots and videos of demo pages via
+  Playwright, depending on `run-demo`
+- docs(Skills): Update `create-pr` skill with label-selection guidance and a follow-up
+  `mcp__github__issue_write` step to apply labels after PR creation
+- docs(Theme): Update the Theme Controller "Theme Radio Inputs" example note to document the automatic
+  syncing, and link the preload-script note to the `ThemeHelper` API docs
+- chore(demo): Switch the header version badge to a "View All Releases" tip linking to the GitHub releases
+  page, and remove the stale issue #49 flash-of-content comment
 
 ### Changed
 
-- **Heroku Configuration**: Added buildpack configuration to
-  <code>app.json</code> for Heroku Review Apps
-  - Added custom <code>loco_motion-buildpack</code> to copy
-    <code>docs/demo</code> subdirectory and gem files
+- **Heroku Configuration**: Added buildpack configuration to <code>app.json</code> for Heroku Review Apps
+  - Added custom <code>loco_motion-buildpack</code> to copy <code>docs/demo</code> subdirectory and gem files
   - Added <code>heroku/ruby</code> and <code>heroku/nodejs</code> buildpacks
-  - Custom buildpack must run first to ensure files are in place before standard
-    buildpacks execute
-- **Developer Tooling**: Add `CLAUDE.md` at the repo root referencing all
-  Windsurf rule files so Claude Code sessions pick up the same coding
-  conventions as Windsurf
+  - Custom buildpack must run first to ensure files are in place before standard buildpacks execute
+- **Developer Tooling**: Add `CLAUDE.md` at the repo root referencing all Windsurf rule files so Claude Code
+  sessions pick up the same coding conventions as Windsurf
   ([Fixes #90](https://github.com/profoundry-us/loco_motion/issues/90))
 
 ## [0.5.2] - 2026-03-05
 
 ### Fixed
 
-- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes
-  and improvements
+- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes and improvements
   - DaisyUI: v5.5.14 → v5.5.19
   - TailwindCSS: v4.1.18 → v4.2.1
   - @tailwindcss/cli: v4.1.18 → v4.2.1
 
 ### Changed
 
-- **Branding**: Updated project logo to modern version across all documentation
-  and examples
-  - Replaced `loco-logo.png` with `loco-logo-modern.png` in navbar and frame
-    examples
+- **Branding**: Updated project logo to modern version across all documentation and examples
+  - Replaced `loco-logo.png` with `loco-logo-modern.png` in navbar and frame examples
   - Updated LLM documentation files to reflect new logo references
   - Added new modern favicon (`loco-favicon.jpg`)
 
@@ -218,27 +165,20 @@ releases** should be considered **breaking**!
 
 ### Fixed
 
-- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes
-  and improvements
-- Remove alpha status badge from the website header as the project is now
-  considered stable
+- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes and improvements
+- Remove alpha status badge from the website header as the project is now considered stable
 
 ### Improved
 
-- **Release Process**: Refactored release workflow to eliminate circular
-  dependency issues
-  - Split `make version-lock` into separate `loco-version-lock` and
-    `demo-version-lock` commands
-  - Added new `bin/update_demo_after_release` script for post-publication demo
-    updates
-  - Updated release documentation to use two-phase approach (package release →
-    demo update)
+- **Release Process**: Refactored release workflow to eliminate circular dependency issues
+  - Split `make version-lock` into separate `loco-version-lock` and `demo-version-lock` commands
+  - Added new `bin/update_demo_after_release` script for post-publication demo updates
+  - Updated release documentation to use two-phase approach (package release → demo update)
   - Reordered release steps to update changelog before building packages
   - Enhanced Makefile targets with NPM package availability checking
-  - **Automated checklist creation**: `make version-bump` and `make version-set`
-    now automatically create personalized release checklists
-- **Documentation**: Added comprehensive release checklist template and improved
-  release guide clarity
+  - **Automated checklist creation**: `make version-bump` and `make version-set` now automatically create
+    personalized release checklists
+- **Documentation**: Added comprehensive release checklist template and improved release guide clarity
 
 ## [0.5.0] - 2025-07-17
 
@@ -246,15 +186,15 @@ releases** should be considered **breaking**!
 
 This is a **MASSIVE** release which touches basically every component!
 
-We've upgraded both TailwindCSS and DaisyUI to the latest major versions (4.x
-and 5.x respectively) with lots of new features and components!
+We've upgraded both TailwindCSS and DaisyUI to the latest major versions (4.x and 5.x respectively) with lots
+of new features and components!
 
 > [!NOTE]
-> Please refer to the [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade)
-> for specific changes to the styling of components.
+> Please refer to the [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade) for specific changes to the
+> styling of components.
 
-We've overhauled the entire docs site to be easier to use (better navigation
-styling) and quicker to navigate (super-fast Algolia search :exploding_head:).
+We've overhauled the entire docs site to be easier to use (better navigation styling) and quicker to navigate
+(super-fast Algolia search :exploding_head:).
 
 We've also added some new components offered by DaisyUI 5 including:
 
@@ -264,8 +204,8 @@ We've also added some new components offered by DaisyUI 5 including:
 
 And we updated many examples to be more clear or show other usage scenarios.
 
-Lastly, we added a TON of tests to ensure that all of the components function as
-designed and will continue to as we add more features.
+Lastly, we added a TON of tests to ensure that all of the components function as designed and will continue to
+as we add more features.
 
 Read on for specific changes across the entire project! :tada:
 
@@ -278,16 +218,13 @@ Read on for specific changes across the entire project! :tada:
   ([Fixes #32](https://github.com/profoundry-us/loco_motion/issues/32))
 - add(Status): Add Status component for displaying visual status indicators
   ([Fixes #30](https://github.com/profoundry-us/loco_motion/issues/30))
-- feat(LabelableComponent): New concern to enable label functionality across
-  components
+- feat(LabelableComponent): New concern to enable label functionality across components
 - feat(Select): Enable start/end/floating label functionality
 - feat(Toggle): Enable start/end/floating label functionality
 - feat(Checkbox): Enable start/end label functionality
-- feat(Filter): Add Filter component for creating selection interfaces with
-  toggle functionality
+- feat(Filter): Add Filter component for creating selection interfaces with toggle functionality
   ([Fixes #33](https://github.com/profoundry-us/loco_motion/issues/33))
-- feat(Cally): Add new Daisy Cally and CallyInput components with date picker
-  functionality
+- feat(Cally): Add new Daisy Cally and CallyInput components with date picker functionality
 - feat(Select): Add support for array and hash options in select component
 - feat(Select): Add floating label support for select inputs
 - feat(Labelable): Enhance labelable component behavior for better form handling
@@ -300,72 +237,56 @@ Read on for specific changes across the entire project! :tada:
   ([PR #42](https://github.com/profoundry-us/loco_motion/pull/42))
 - **Breaking:** Update existing components for DaisyUI 5 compatibility
   ([PR #28](https://github.com/profoundry-us/loco_motion/pull/28))
-- **Breaking:** All inputs now have a border by default, use `input-ghost` (or
-  `*-input-ghost`) to remove (see
+- **Breaking:** All inputs now have a border by default, use `input-ghost` (or `*-input-ghost`) to remove (see
   [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade))
-- **Breaking:** Migrated BottomNav component to Dock component to match DaisyUI
-  5 changes
+- **Breaking:** Migrated BottomNav component to Dock component to match DaisyUI 5 changes
   ([Fixes #40](https://github.com/profoundry-us/loco_motion/issues/40)):
   - `BottomNavComponent` → `DockComponent`
   - Helper method `daisy_bottom_nav` → `daisy_dock`
-  - Updated all CSS classes, slot/part names, and icon rendering to new
-    conventions
+  - Updated all CSS classes, slot/part names, and icon rendering to new conventions
   - Example views and tests updated accordingly
-  - This is a breaking change: update any usages of the old component and helper
-    to the new names and API
-- feat: Allow users to pass singular `controller:` keyword in addition to
-  `controllers:`
-- refactor: Implement Concern Lifecycle Hooks in `BaseComponent` for consistent
-  initialization and setup
+  - This is a breaking change: update any usages of the old component and helper to the new names and API
+- feat: Allow users to pass singular `controller:` keyword in addition to `controllers:`
+- refactor: Implement Concern Lifecycle Hooks in `BaseComponent` for consistent initialization and setup
   ([PR #54](https://github.com/profoundry-us/loco_motion/pull/54))
 - refactor: Move component concerns to lib directory for better organization
-- test: Add comprehensive tests for IconableComponent, LinkableComponent, and
-  TippableComponent
-- refactor: The Loco parent is now set automatically in slots
-  (`slot_loco_parent_patch.rb`) and you can pass the `loco_parent` option when
-  creating a new component to set it manually when needed
+- test: Add comprehensive tests for IconableComponent, LinkableComponent, and TippableComponent
+- refactor: The Loco parent is now set automatically in slots (`slot_loco_parent_patch.rb`) and you can pass
+  the `loco_parent` option when creating a new component to set it manually when needed
 
 #### Component Changes
 
-- **Breaking:** remove(Artboard): Remove Artboard component no longer offered by
-  DaisyUI 5 ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
-- **Breaking:** refactor(Device): Utilize standard Tailwind width/height classes
-  instead of Artboard
+- **Breaking:** remove(Artboard): Remove Artboard component no longer offered by DaisyUI 5
+  ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
+- **Breaking:** refactor(Device): Utilize standard Tailwind width/height classes instead of Artboard
   ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
 - **Breaking:** refactor(ThemeController): Migrate to a "Builder" component
   ([Fixes #38](https://github.com/profoundry-us/loco_motion/issues/38))
-- **Breaking:** remove(`form-control`): Remove all references to DaisyUI 4
-  `form-control` class (including specs)
-- **Breaking:** change(Modal): Modal titles now render as an `<h4>` instead of a
-  `<div>`
-- **Breaking:** change(Icon): Hero icons now use the
-  https://rubygems.org/gems/rails_heroicon library which means the existing
-  `heroicon_tag` helper is replaced with the `heroicon` helper
+- **Breaking:** remove(`form-control`): Remove all references to DaisyUI 4 `form-control` class (including
+  specs)
+- **Breaking:** change(Modal): Modal titles now render as an `<h4>` instead of a `<div>`
+- **Breaking:** change(Icon): Hero icons now use the https://rubygems.org/gems/rails_heroicon library which
+  means the existing `heroicon_tag` helper is replaced with the `heroicon` helper
   ([Fixes #47](https://github.com/profoundry-us/loco_motion/issues/47))
 
-- feat(Avatar): Add support for icons and linking via `IconableComponent` and
-  `LinkableComponent`
-- feat(Badge): Add support for icons and linking and styling, including new
-  `badge-soft` and `badge-dashed` variants
-- feat(Button): Enhanced with new features and styling, including new `btn-soft`
-  and `btn-dashed` variants
-- feat(Alert): Enhanced with new styling options, including `alert-soft` and
-  `alert-dashed` variants
+- feat(Avatar): Add support for icons and linking via `IconableComponent` and `LinkableComponent`
+- feat(Badge): Add support for icons and linking and styling, including new `badge-soft` and `badge-dashed`
+  variants
+- feat(Button): Enhanced with new features and styling, including new `btn-soft` and `btn-dashed` variants
+- feat(Alert): Enhanced with new styling options, including `alert-soft` and `alert-dashed` variants
 - feat(Breadcrumbs): Refined implementation for better usability
 - feat(Menu): Enhanced styling and functionality
 - feat(Steps): Enhanced for better visual presentation
 - feat(Tabs): Added five different size options (xs, sm, md, lg, xl)
 - feat(Input): Add `daisy_input` alias helper in addition to `daisy_text_input`
 - fix(Link): Tooltips now work correctly
-- fix(Dropdown): Simplify item rendering and add `where:` modifier to relevant
-  CSS classes
+- fix(Dropdown): Simplify item rendering and add `where:` modifier to relevant CSS classes
 - fix(KBD): Accept a simple title
 - fix(Modal): Only show actions part if provided
 - fix(Modal): Remove unnecessary `:dialog` part from component definition
   ([Fixes #46](https://github.com/profoundry-us/loco_motion/issues/46))
 - fix(Navbar): Improved implementation and styling
-- refactor(DocExample): Renamed from `ExampleWrapper` for better semantics and
-  improved code organization
+- refactor(DocExample): Renamed from `ExampleWrapper` for better semantics and improved code organization
 - fix(Fieldset): Fix issue with fieldset textarea rendering
 
 #### Demo / Docs Changes
@@ -376,8 +297,7 @@ Read on for specific changes across the entire project! :tada:
 - fix: Padding issue with ThemeController
 - fix: Issues with swaps (rotation issue remains)
 - fix: Navigation not updating active state on selection
-- fix: Padding issue on Dropdowns example by upgrading to latest Tailwind
-  insiders
+- fix: Padding issue on Dropdowns example by upgrading to latest Tailwind insiders
 - feat: Dark mode toggle functionality
 - fix: Device mockups in dark mode
 - fix: Header and buttons in dark mode
@@ -403,30 +323,23 @@ Read on for specific changes across the entire project! :tada:
 - fix: Border to bottom figure example
 - feat: Standardize H1/H2 doc headings
 - feat: Enhanced navigation with icons, colors, and improved padding
-- add: Algolia search indexing and UI
-  ([Fixes #37](https://github.com/profoundry-us/loco_motion/issues/37))
-- feat(AlgoliaSearch): Add auto-selection of first search result on query for
-  improved UX
-- refactor: Renamed `ExampleWrapper` doc component to `DocExample` for better
-  semantics
-- fix: Converted most uses of code blocks to markdown backticks for improved
-  readability
+- add: Algolia search indexing and UI ([Fixes #37](https://github.com/profoundry-us/loco_motion/issues/37))
+- feat(AlgoliaSearch): Add auto-selection of first search result on query for improved UX
+- refactor: Renamed `ExampleWrapper` doc component to `DocExample` for better semantics
+- fix: Converted most uses of code blocks to markdown backticks for improved readability
 - fix(DocNote): Fix purple TODO variant text color.
 - refactor: Merge `application.js` functionality into `index.js`
 - feat: Add Theme Switcher dropdown to header
 - fix: Fix header item spacing / padding on smaller screens
-- fix: Rename `Data` group to `Data Display` to match component module & DaisyUI
-  5
+- fix: Rename `Data` group to `Data Display` to match component module & DaisyUI 5
 - fix: Make Label docs show better buttons for implementing components
 - fix: Add tooltips to header buttons and make logo a link
 - fix: Always enable BetterErrors in development
 - fix: Header Theme Switcher was using the wrong button size
-- feat: Add soft, outline, and dash style examples to Alert, Badge, and Button
-  examples ([Fixes #36](https://github.com/profoundry-us/loco_motion/issues/36))
-- feat: Updated component documentation to use `@loco_example` tag for better
-  organization
-- add(DocNote): Add new error modifier to doc_note component for improved
-  documentation
+- feat: Add soft, outline, and dash style examples to Alert, Badge, and Button examples
+  ([Fixes #36](https://github.com/profoundry-us/loco_motion/issues/36))
+- feat: Updated component documentation to use `@loco_example` tag for better organization
+- add(DocNote): Add new error modifier to doc_note component for improved documentation
 - fix: Fix issue with figures not showing captions
 - fix: Fix typo in select docs
 - fix: Add check in set_loco_parent_patch to ensure we catch nil references
@@ -436,15 +349,13 @@ Read on for specific changes across the entire project! :tada:
 
 ## [0.4.0] - 2025-03-07
 
-This version is a major milestone as it finishes out a basic version of all of
-the DaisyUI 4 components!
+This version is a major milestone as it finishes out a basic version of all of the DaisyUI 4 components!
 
-While this gives us a solid foundation to start using the components, we feel
-that our time will best be spent upgrading the configuration and components to
-utilize the new DaisyUI 5 framework that was recently released.
+While this gives us a solid foundation to start using the components, we feel that our time will best be spent
+upgrading the configuration and components to utilize the new DaisyUI 5 framework that was recently released.
 
-We will be migrating to the new version and all bug fixes / improvements will be
-made in a new LocoMotion 0.5.0 branch / release.
+We will be migrating to the new version and all bug fixes / improvements will be made in a new LocoMotion
+0.5.0 branch / release.
 
 ### Added
 
@@ -494,8 +405,7 @@ made in a new LocoMotion 0.5.0 branch / release.
 
 ### Fixed
 
-- Fixed Button component bug where styles were not always applied with icon
-  options
+- Fixed Button component bug where styles were not always applied with icon options
 - Fixed compatibility issues between the gem and the demo app
 - Fixed Gemfile.lock not getting saved properly during version updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to LocoMotion will be documented in this file.
 
-The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project _mostly_ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is loosely based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+_mostly_ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 We say mostly because all versions before 1.0.0 will likely have breaking
 changes as we don't consider the project "released" until that point in time.
@@ -15,96 +16,201 @@ releases** should be considered **breaking**!
 
 ### Components Changes
 
-- fix(Theme): Add `theme_preload_script` helper to prevent flash of content when loading with non-default theme ([Fixes #49](https://github.com/profoundry-us/loco_motion/issues/49))
-- fix(Theme): Update `clearTheme` method to remove `data-theme` attribute from document element, preventing need for page refresh when clearing theme
+- fix(Theme): Add `theme_preload_script` helper to prevent flash of content when
+  loading with non-default theme
+  ([Fixes #49](https://github.com/profoundry-us/loco_motion/issues/49))
+- fix(Theme): Update `clearTheme` method to remove `data-theme` attribute from
+  document element, preventing need for page refresh when clearing theme
 
-- feat(DataInput): Add `AriableComponent` concern to Checkbox, Toggle, RadioButton, TextInput, TextArea, Select, Range, and FileInput that automatically sets `aria-required="true"` when `required: true` is passed (unless the user provides `aria-required` explicitly)
-- feat(RadioButton): Add LabelableComponent concern with start/end label support and custom content blocks
-- feat(Checkbox): Add label examples for start/end labels and custom content blocks
-- feat(Join): Add automatic `join-item` CSS class injection for items slot using `BasicComponent.build(css: "join-item")`
-- feat(Join): Add `buttons` slot using `ButtonComponent.build(css: "join-item")` for automatic CSS class injection
-- feat(Join): Add `radios` slot using `RadioButtonComponent.build(skip_styling: true, css: "join-item btn")` for automatic CSS class injection
-- feat(Join): Update call method to handle items, buttons, radios, or direct content
-- fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES` constant so `diff-item-1` / `diff-item-2` are detected as string literals by Tailwind v4's Ruby extractor ([Fixes #82](https://github.com/profoundry-us/loco_motion/issues/82))
-- add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D cards via `LinkableComponent` ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
-- feat(HoverGallery): Add new `Daisy::Layout::HoverGalleryComponent` (`daisy_hover_gallery`) with slot-based `with_image` API, `srcs:` convenience shorthand, content fallback for custom block markup, and demo examples ([Fixes #96](https://github.com/profoundry-us/loco_motion/issues/96))
-- fix(HoverGallery): Replace non-existent `set_tag` with `set_tag_name` in `setup_component`, and move `ImageComponent` tag assignment from `initialize` to `before_render` via `set_tag_name(:component, :img)`
-- fix(Avatar): Suppress `where:bg-neutral` default on placeholder wrapper when `skeleton` is in `wrapper_css`, preventing the neutral background from bleeding through the skeleton shimmer gradient ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
-- fix(Skeleton): Standardize text-hiding in component skeleton examples (`text-transparent` consistently); add `skeleton-text` example and docs for DaisyUI 5's animated text shimmer class ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
-- feat(DataDisplay): Add new `Daisy::DataDisplay::TextRotateComponent` (`daisy_text_rotate`) with `ItemComponent` slot, `texts:` shorthand parameter, a `wrapper` part (`wrapper_css:`) around the items, tooltip support, custom block content (rendered after items), and per-item link (`href`) / icon (`left_icon`/`right_icon`) support via `LinkableComponent` and `IconableComponent` ([Fixes #110](https://github.com/profoundry-us/loco_motion/issues/110))
-- feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent` feature parity ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
-- feat(Navbar): Allow custom content to be passed directly inside the component's block in addition to the existing `start`, `center`, and `end` slots ([Fixes #83](https://github.com/profoundry-us/loco_motion/issues/83))
-- feat(Alert): Add auto-dismiss functionality with `autoclose` and `timeout` parameters
-- feat(Alert): Add clickable link functionality with `href` and `target` parameters
+- feat(DataInput): Add `AriableComponent` concern to Checkbox, Toggle,
+  RadioButton, TextInput, TextArea, Select, Range, and FileInput that
+  automatically sets `aria-required="true"` when `required: true` is passed
+  (unless the user provides `aria-required` explicitly)
+- feat(RadioButton): Add LabelableComponent concern with start/end label support
+  and custom content blocks
+- feat(Checkbox): Add label examples for start/end labels and custom content
+  blocks
+- feat(Join): Add automatic `join-item` CSS class injection for items slot using
+  `BasicComponent.build(css: "join-item")`
+- feat(Join): Add `buttons` slot using `ButtonComponent.build(css: "join-item")`
+  for automatic CSS class injection
+- feat(Join): Add `radios` slot using
+  `RadioButtonComponent.build(skip_styling: true, css: "join-item btn")` for
+  automatic CSS class injection
+- feat(Join): Update call method to handle items, buttons, radios, or direct
+  content
+- fix(Diff): Replace comment-based Tailwind class safelist with `ITEM_CLASSES`
+  constant so `diff-item-1` / `diff-item-2` are detected as string literals by
+  Tailwind v4's Ruby extractor
+  ([Fixes #82](https://github.com/profoundry-us/loco_motion/issues/82))
+- add(Hover): Add new `Daisy::Layout::HoverComponent` (`daisy_hover`) wrapping
+  DaisyUI's `hover-3d` effect, with optional `href:`/`target:` for clickable 3D
+  cards via `LinkableComponent`
+  ([Fixes #80](https://github.com/profoundry-us/loco_motion/issues/80))
+- feat(HoverGallery): Add new `Daisy::Layout::HoverGalleryComponent`
+  (`daisy_hover_gallery`) with slot-based `with_image` API, `srcs:` convenience
+  shorthand, content fallback for custom block markup, and demo examples
+  ([Fixes #96](https://github.com/profoundry-us/loco_motion/issues/96))
+- fix(HoverGallery): Replace non-existent `set_tag` with `set_tag_name` in
+  `setup_component`, and move `ImageComponent` tag assignment from `initialize`
+  to `before_render` via `set_tag_name(:component, :img)`
+- fix(Avatar): Suppress `where:bg-neutral` default on placeholder wrapper when
+  `skeleton` is in `wrapper_css`, preventing the neutral background from
+  bleeding through the skeleton shimmer gradient
+  ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
+- fix(Skeleton): Standardize text-hiding in component skeleton examples
+  (`text-transparent` consistently); add `skeleton-text` example and docs for
+  DaisyUI 5's animated text shimmer class
+  ([Fixes #98](https://github.com/profoundry-us/loco_motion/issues/98))
+- feat(DataDisplay): Add new `Daisy::DataDisplay::TextRotateComponent`
+  (`daisy_text_rotate`) with `ItemComponent` slot, `texts:` shorthand parameter,
+  a `wrapper` part (`wrapper_css:`) around the items, tooltip support, custom
+  block content (rendered after items), and per-item link (`href`) / icon
+  (`left_icon`/`right_icon`) support via `LinkableComponent` and
+  `IconableComponent`
+  ([Fixes #110](https://github.com/profoundry-us/loco_motion/issues/110))
+- feat(Link): Add icon support (`icon`, `left_icon`, `right_icon`) to
+  `LinkComponent` via `IconableComponent` concern, matching `ButtonComponent`
+  feature parity
+  ([Fixes #84](https://github.com/profoundry-us/loco_motion/issues/84))
+- feat(Navbar): Allow custom content to be passed directly inside the
+  component's block in addition to the existing `start`, `center`, and `end`
+  slots ([Fixes #83](https://github.com/profoundry-us/loco_motion/issues/83))
+- feat(Alert): Add auto-dismiss functionality with `autoclose` and `timeout`
+  parameters
+- feat(Alert): Add clickable link functionality with `href` and `target`
+  parameters
 - feat(Alert): Add Stimulus action support with `action` parameter
-- feat(Alert): Add closable functionality with `closable` parameter and close button
-- feat(Alert): Add AlertController to NPM package for client-side alert management
+- feat(Alert): Add closable functionality with `closable` parameter and close
+  button
+- feat(Alert): Add AlertController to NPM package for client-side alert
+  management
 - feat(Configuration): Add comprehensive documentation to Configuration class
-- add(FAB): Add new `Daisy::Actions::FabComponent` (`daisy_fab`) implementing the DaisyUI FAB / Speed Dial pattern with `button`, `activator`, and `action` slots ([Fixes #93](https://github.com/profoundry-us/loco_motion/issues/93))
-- fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 by removing dead `!mt-0` hack and moving sizing to the container via `css:` (override `aspect-ratio`, `max-width`, `border-radius`) instead of `display_css` ([Fixes #99](https://github.com/profoundry-us/loco_motion/issues/99))
-- fix(Theme): Auto-sync the selected theme across every theme selector on the page by watching `change` events and making `setInput` uncheck stale inputs, so a selection in one switcher is no longer silently overridden by another; radio inputs now persist to `localStorage` automatically with no `setTheme` action wiring ([Fixes #115](https://github.com/profoundry-us/loco_motion/issues/115))
-- fix(Theme): Namespace `build_radio_input` ids by input name (`"#{name}-#{theme}"`) to avoid duplicate ids when multiple theme controllers share a page
+- add(FAB): Add new `Daisy::Actions::FabComponent` (`daisy_fab`) implementing
+  the DaisyUI FAB / Speed Dial pattern with `button`, `activator`, and `action`
+  slots ([Fixes #93](https://github.com/profoundry-us/loco_motion/issues/93))
+- fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 by removing dead
+  `!mt-0` hack and moving sizing to the container via `css:` (override
+  `aspect-ratio`, `max-width`, `border-radius`) instead of `display_css`
+  ([Fixes #99](https://github.com/profoundry-us/loco_motion/issues/99))
+- fix(Theme): Auto-sync the selected theme across every theme selector on the
+  page by watching `change` events and making `setInput` uncheck stale inputs,
+  so a selection in one switcher is no longer silently overridden by another;
+  radio inputs now persist to `localStorage` automatically with no `setTheme`
+  action wiring
+  ([Fixes #115](https://github.com/profoundry-us/loco_motion/issues/115))
+- fix(Theme): Namespace `build_radio_input` ids by input name
+  (`"#{name}-#{theme}"`) to avoid duplicate ids when multiple theme controllers
+  share a page
 
 ### General Changes
 
 - chore(Skills): Split `start-issue` into two focused skills: `create-issue`
   (investigate → draft → post a GitHub issue) and `start-issue` (read an
   existing issue, propose a branch, optionally plan)
-- feat(BaseComponent): Add universal `aria:` / `data:` shorthands (and per-part `{part}_aria` / `{part}_data`) that deep-merge into a part's HTML, so `aria: { label: "Save" }` renders `aria-label="Save"` without nesting inside `html:`
-- feat(ComponentConfig): Add `add_aria` / `add_data` author helpers (delegated from `BaseComponent`) for setting default `aria-*` / `data-*` attributes on a part
-- feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
-- feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
-- feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern
-- chore(justfile): Rename the `*-quick` targets (`all-quick`, `loco-quick`, `demo-quick`, `yard-quick`) to `*-fast`
+- feat(BaseComponent): Add universal `aria:` / `data:` shorthands (and per-part
+  `{part}_aria` / `{part}_data`) that deep-merge into a part's HTML, so
+  `aria: { label: "Save" }` renders `aria-label="Save"` without nesting inside
+  `html:`
+- feat(ComponentConfig): Add `add_aria` / `add_data` author helpers (delegated
+  from `BaseComponent`) for setting default `aria-*` / `data-*` attributes on a
+  part
+- feat(BaseComponent): Improve `build` method to merge build_kws into config
+  before initialize for proper precedence
+- feat(BaseComponent): Update instance variables for build_kws keys after
+  initialize to ensure options like `skip_styling` are available during
+  `setup_component`
+- feat(RadioButton): Move rendering from call method to HAML template to match
+  CheckboxComponent pattern
+- chore(justfile): Rename the `*-quick` targets (`all-quick`, `loco-quick`,
+  `demo-quick`, `yard-quick`) to `*-fast`
 
 ### Demo / Docs Changes
 
-- fix(demo): Add `ads_preload_script` helper to prevent flash of ads content when page loads
-- fix(demo): Move `ads_preload_script` after ads element in layout since it needs to query for specific DOM elements
-- fix(demo): Add Playwright test to verify ads visibility is set correctly on non-hidden pages
-- add(Docs): Add missing page titles to Install, LLMs, Docker, HAML, and Debugging pages
-- feat(Join): Update join examples to use `with_button` slot instead of `with_item` for buttons
-- feat(Join): Add expansive direct content example with input, select, and indicator components
+- fix(demo): Add `ads_preload_script` helper to prevent flash of ads content
+  when page loads
+- fix(demo): Move `ads_preload_script` after ads element in layout since it
+  needs to query for specific DOM elements
+- fix(demo): Add Playwright test to verify ads visibility is set correctly on
+  non-hidden pages
+- add(Docs): Add missing page titles to Install, LLMs, Docker, HAML, and
+  Debugging pages
+- feat(Join): Update join examples to use `with_button` slot instead of
+  `with_item` for buttons
+- feat(Join): Add expansive direct content example with input, select, and
+  indicator components
 - feat(RadioButton): Add radio buttons with labels examples to demo
-- add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image gallery examples
-- add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in network-restricted environments (e.g. Claude Code cloud) where OS package repos are blocked; uses a multi-stage build to copy Node.js from `node:20-slim` instead of installing via `nodesource`
-- add(Navbar): Add "Custom Content Navbar" example demonstrating block-based custom content
-- feat(Alert): Add closable, auto-dismissing, clickable link, and Stimulus action alert examples
+- add(Hover): Add "Hover 3D" demo page with basic, clickable card, and image
+  gallery examples
+- add(Demo): Add `Dockerfile.demo.cloud` for building the demo app in
+  network-restricted environments (e.g. Claude Code cloud) where OS package
+  repos are blocked; uses a multi-stage build to copy Node.js from
+  `node:20-slim` instead of installing via `nodesource`
+- add(Navbar): Add "Custom Content Navbar" example demonstrating block-based
+  custom content
+- feat(Alert): Add closable, auto-dismissing, clickable link, and Stimulus
+  action alert examples
 - feat(Alert): Add AlertDemoController for interactive click celebration demo
-- feat(Toast): Enhance Toast examples with closable, auto-dismiss, and clickable features
+- feat(Toast): Enhance Toast examples with closable, auto-dismiss, and clickable
+  features
 - feat(Toast): Add Toast positions example and reset functionality
 - docs(Toast): Update documentation to warn about AlertController dependency
 - docs(Alert): Update Alert examples with improved descriptions and formatting
-- add(FAB): Add FAB demo page with simple, speed dial, flower, and custom activator examples
-- add(HoverGallery): Add Hover Galleries demo page with Basic, In a Card, and Shorthand (`srcs:`) examples
-- add(TextRotate): Add Text Rotates demo page with examples for Basic usage, `texts:` shorthand, Centered Items (`wrapper_css:`), Icons and Links (per-item `icon`/`left_icon`/`right_icon` and `href`), Custom Content (custom block markup with inline `daisy_avatar`s beside the text), Custom Duration (3s/6s/10s), Inline in a Sentence, Different Font Sizes, and Custom Line Height
-- docs(Skills): Add `run-demo` skill for booting the demo Rails app locally without Docker, including Ruby/Node version handling, vendor symlink setup, and the `file:../..` + `--no-lockfile` yarn pattern to avoid polluting `yarn.lock`
-- docs(Skills): Add `screenshot-demo` skill for capturing full-page screenshots and videos of demo pages via Playwright, depending on `run-demo`
-- docs(Skills): Update `create-pr` skill with label-selection guidance and a follow-up `mcp__github__issue_write` step to apply labels after PR creation
-- docs(Theme): Update the Theme Controller "Theme Radio Inputs" example note to document the automatic syncing, and link the preload-script note to the `ThemeHelper` API docs
-- chore(demo): Switch the header version badge to a "View All Releases" tip linking to the GitHub releases page, and remove the stale issue #49 flash-of-content comment
+- add(FAB): Add FAB demo page with simple, speed dial, flower, and custom
+  activator examples
+- add(HoverGallery): Add Hover Galleries demo page with Basic, In a Card, and
+  Shorthand (`srcs:`) examples
+- add(TextRotate): Add Text Rotates demo page with examples for Basic usage,
+  `texts:` shorthand, Centered Items (`wrapper_css:`), Icons and Links (per-item
+  `icon`/`left_icon`/`right_icon` and `href`), Custom Content (custom block
+  markup with inline `daisy_avatar`s beside the text), Custom Duration
+  (3s/6s/10s), Inline in a Sentence, Different Font Sizes, and Custom Line
+  Height
+- docs(Skills): Add `run-demo` skill for booting the demo Rails app locally
+  without Docker, including Ruby/Node version handling, vendor symlink setup,
+  and the `file:../..` + `--no-lockfile` yarn pattern to avoid polluting
+  `yarn.lock`
+- docs(Skills): Add `screenshot-demo` skill for capturing full-page screenshots
+  and videos of demo pages via Playwright, depending on `run-demo`
+- docs(Skills): Update `create-pr` skill with label-selection guidance and a
+  follow-up `mcp__github__issue_write` step to apply labels after PR creation
+- docs(Theme): Update the Theme Controller "Theme Radio Inputs" example note to
+  document the automatic syncing, and link the preload-script note to the
+  `ThemeHelper` API docs
+- chore(demo): Switch the header version badge to a "View All Releases" tip
+  linking to the GitHub releases page, and remove the stale issue #49
+  flash-of-content comment
 
 ### Changed
 
-- **Heroku Configuration**: Added buildpack configuration to <code>app.json</code> for Heroku Review Apps
-  - Added custom <code>loco_motion-buildpack</code> to copy <code>docs/demo</code> subdirectory and gem files
+- **Heroku Configuration**: Added buildpack configuration to
+  <code>app.json</code> for Heroku Review Apps
+  - Added custom <code>loco_motion-buildpack</code> to copy
+    <code>docs/demo</code> subdirectory and gem files
   - Added <code>heroku/ruby</code> and <code>heroku/nodejs</code> buildpacks
-  - Custom buildpack must run first to ensure files are in place before standard buildpacks execute
-- **Developer Tooling**: Add `CLAUDE.md` at the repo root referencing all Windsurf rule files so Claude Code sessions pick up the same coding conventions as Windsurf ([Fixes #90](https://github.com/profoundry-us/loco_motion/issues/90))
+  - Custom buildpack must run first to ensure files are in place before standard
+    buildpacks execute
+- **Developer Tooling**: Add `CLAUDE.md` at the repo root referencing all
+  Windsurf rule files so Claude Code sessions pick up the same coding
+  conventions as Windsurf
+  ([Fixes #90](https://github.com/profoundry-us/loco_motion/issues/90))
 
 ## [0.5.2] - 2026-03-05
 
 ### Fixed
 
-- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes and improvements
+- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes
+  and improvements
   - DaisyUI: v5.5.14 → v5.5.19
   - TailwindCSS: v4.1.18 → v4.2.1
   - @tailwindcss/cli: v4.1.18 → v4.2.1
 
 ### Changed
 
-- **Branding**: Updated project logo to modern version across all documentation and examples
-  - Replaced `loco-logo.png` with `loco-logo-modern.png` in navbar and frame examples
+- **Branding**: Updated project logo to modern version across all documentation
+  and examples
+  - Replaced `loco-logo.png` with `loco-logo-modern.png` in navbar and frame
+    examples
   - Updated LLM documentation files to reflect new logo references
   - Added new modern favicon (`loco-favicon.jpg`)
 
@@ -112,19 +218,27 @@ releases** should be considered **breaking**!
 
 ### Fixed
 
-- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes and improvements
-- Remove alpha status badge from the website header as the project is now considered stable
+- Update DaisyUI and TailwindCSS to their latest patch versions for bug fixes
+  and improvements
+- Remove alpha status badge from the website header as the project is now
+  considered stable
 
 ### Improved
 
-- **Release Process**: Refactored release workflow to eliminate circular dependency issues
-  - Split `make version-lock` into separate `loco-version-lock` and `demo-version-lock` commands
-  - Added new `bin/update_demo_after_release` script for post-publication demo updates
-  - Updated release documentation to use two-phase approach (package release → demo update)
+- **Release Process**: Refactored release workflow to eliminate circular
+  dependency issues
+  - Split `make version-lock` into separate `loco-version-lock` and
+    `demo-version-lock` commands
+  - Added new `bin/update_demo_after_release` script for post-publication demo
+    updates
+  - Updated release documentation to use two-phase approach (package release →
+    demo update)
   - Reordered release steps to update changelog before building packages
   - Enhanced Makefile targets with NPM package availability checking
-  - **Automated checklist creation**: `make version-bump` and `make version-set` now automatically create personalized release checklists
-- **Documentation**: Added comprehensive release checklist template and improved release guide clarity
+  - **Automated checklist creation**: `make version-bump` and `make version-set`
+    now automatically create personalized release checklists
+- **Documentation**: Added comprehensive release checklist template and improved
+  release guide clarity
 
 ## [0.5.0] - 2025-07-17
 
@@ -158,15 +272,22 @@ Read on for specific changes across the entire project! :tada:
 ### Added
 
 - add(`where:`): Add custom `where:` Tailwind modifier
-- add(List): Add basic List component with examples and specs ([Fixes #29](https://github.com/profoundry-us/loco_motion/issues/29))
-- add(Fieldset): Add Fieldset component for grouping related form elements ([Fixes #32](https://github.com/profoundry-us/loco_motion/issues/32))
-- add(Status): Add Status component for displaying visual status indicators ([Fixes #30](https://github.com/profoundry-us/loco_motion/issues/30))
-- feat(LabelableComponent): New concern to enable label functionality across components
+- add(List): Add basic List component with examples and specs
+  ([Fixes #29](https://github.com/profoundry-us/loco_motion/issues/29))
+- add(Fieldset): Add Fieldset component for grouping related form elements
+  ([Fixes #32](https://github.com/profoundry-us/loco_motion/issues/32))
+- add(Status): Add Status component for displaying visual status indicators
+  ([Fixes #30](https://github.com/profoundry-us/loco_motion/issues/30))
+- feat(LabelableComponent): New concern to enable label functionality across
+  components
 - feat(Select): Enable start/end/floating label functionality
 - feat(Toggle): Enable start/end/floating label functionality
 - feat(Checkbox): Enable start/end label functionality
-- feat(Filter): Add Filter component for creating selection interfaces with toggle functionality ([Fixes #33](https://github.com/profoundry-us/loco_motion/issues/33))
-- feat(Cally): Add new Daisy Cally and CallyInput components with date picker functionality
+- feat(Filter): Add Filter component for creating selection interfaces with
+  toggle functionality
+  ([Fixes #33](https://github.com/profoundry-us/loco_motion/issues/33))
+- feat(Cally): Add new Daisy Cally and CallyInput components with date picker
+  functionality
 - feat(Select): Add support for array and hash options in select component
 - feat(Select): Add floating label support for select inputs
 - feat(Labelable): Enhance labelable component behavior for better form handling
@@ -175,48 +296,76 @@ Read on for specific changes across the entire project! :tada:
 
 #### General Changes
 
-- **Breaking:** Upgrade from TailwindCSS 3.x to 4.x and DaisyUI 4.x to 5.x ([PR #42](https://github.com/profoundry-us/loco_motion/pull/42))
-- **Breaking:** Update existing components for DaisyUI 5 compatibility ([PR #28](https://github.com/profoundry-us/loco_motion/pull/28))
+- **Breaking:** Upgrade from TailwindCSS 3.x to 4.x and DaisyUI 4.x to 5.x
+  ([PR #42](https://github.com/profoundry-us/loco_motion/pull/42))
+- **Breaking:** Update existing components for DaisyUI 5 compatibility
+  ([PR #28](https://github.com/profoundry-us/loco_motion/pull/28))
 - **Breaking:** All inputs now have a border by default, use `input-ghost` (or
-  `*-input-ghost`) to remove (see [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade))
-- **Breaking:** Migrated BottomNav component to Dock component to match DaisyUI 5 changes ([Fixes #40](https://github.com/profoundry-us/loco_motion/issues/40)):
+  `*-input-ghost`) to remove (see
+  [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade))
+- **Breaking:** Migrated BottomNav component to Dock component to match DaisyUI
+  5 changes
+  ([Fixes #40](https://github.com/profoundry-us/loco_motion/issues/40)):
   - `BottomNavComponent` → `DockComponent`
   - Helper method `daisy_bottom_nav` → `daisy_dock`
-  - Updated all CSS classes, slot/part names, and icon rendering to new conventions
+  - Updated all CSS classes, slot/part names, and icon rendering to new
+    conventions
   - Example views and tests updated accordingly
-  - This is a breaking change: update any usages of the old component and helper to the new names and API
-- feat: Allow users to pass singular `controller:` keyword in addition to `controllers:`
-- refactor: Implement Concern Lifecycle Hooks in `BaseComponent` for consistent initialization and setup ([PR #54](https://github.com/profoundry-us/loco_motion/pull/54))
+  - This is a breaking change: update any usages of the old component and helper
+    to the new names and API
+- feat: Allow users to pass singular `controller:` keyword in addition to
+  `controllers:`
+- refactor: Implement Concern Lifecycle Hooks in `BaseComponent` for consistent
+  initialization and setup
+  ([PR #54](https://github.com/profoundry-us/loco_motion/pull/54))
 - refactor: Move component concerns to lib directory for better organization
-- test: Add comprehensive tests for IconableComponent, LinkableComponent, and TippableComponent
-- refactor: The Loco parent is now set automatically in slots (`slot_loco_parent_patch.rb`) and you can
-  pass the `loco_parent` option when creating a new component to set it manually when needed
+- test: Add comprehensive tests for IconableComponent, LinkableComponent, and
+  TippableComponent
+- refactor: The Loco parent is now set automatically in slots
+  (`slot_loco_parent_patch.rb`) and you can pass the `loco_parent` option when
+  creating a new component to set it manually when needed
 
 #### Component Changes
 
-- **Breaking:** remove(Artboard): Remove Artboard component no longer offered by DaisyUI 5 ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
-- **Breaking:** refactor(Device): Utilize standard Tailwind width/height classes instead of Artboard ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
-- **Breaking:** refactor(ThemeController): Migrate to a "Builder" component ([Fixes #38](https://github.com/profoundry-us/loco_motion/issues/38))
-- **Breaking:** remove(`form-control`): Remove all references to DaisyUI 4 `form-control` class (including specs)
-- **Breaking:** change(Modal): Modal titles now render as an `<h4>` instead of a `<div>`
-- **Breaking:** change(Icon): Hero icons now use the https://rubygems.org/gems/rails_heroicon library which means the existing `heroicon_tag` helper is replaced with the `heroicon` helper ([Fixes #47](https://github.com/profoundry-us/loco_motion/issues/47))
+- **Breaking:** remove(Artboard): Remove Artboard component no longer offered by
+  DaisyUI 5 ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
+- **Breaking:** refactor(Device): Utilize standard Tailwind width/height classes
+  instead of Artboard
+  ([PR #43](https://github.com/profoundry-us/loco_motion/pull/43))
+- **Breaking:** refactor(ThemeController): Migrate to a "Builder" component
+  ([Fixes #38](https://github.com/profoundry-us/loco_motion/issues/38))
+- **Breaking:** remove(`form-control`): Remove all references to DaisyUI 4
+  `form-control` class (including specs)
+- **Breaking:** change(Modal): Modal titles now render as an `<h4>` instead of a
+  `<div>`
+- **Breaking:** change(Icon): Hero icons now use the
+  https://rubygems.org/gems/rails_heroicon library which means the existing
+  `heroicon_tag` helper is replaced with the `heroicon` helper
+  ([Fixes #47](https://github.com/profoundry-us/loco_motion/issues/47))
 
-- feat(Avatar): Add support for icons and linking via `IconableComponent` and `LinkableComponent`
-- feat(Badge): Add support for icons and linking and styling, including new `badge-soft` and `badge-dashed` variants
-- feat(Button): Enhanced with new features and styling, including new `btn-soft` and `btn-dashed` variants
-- feat(Alert): Enhanced with new styling options, including `alert-soft` and `alert-dashed` variants
+- feat(Avatar): Add support for icons and linking via `IconableComponent` and
+  `LinkableComponent`
+- feat(Badge): Add support for icons and linking and styling, including new
+  `badge-soft` and `badge-dashed` variants
+- feat(Button): Enhanced with new features and styling, including new `btn-soft`
+  and `btn-dashed` variants
+- feat(Alert): Enhanced with new styling options, including `alert-soft` and
+  `alert-dashed` variants
 - feat(Breadcrumbs): Refined implementation for better usability
 - feat(Menu): Enhanced styling and functionality
 - feat(Steps): Enhanced for better visual presentation
 - feat(Tabs): Added five different size options (xs, sm, md, lg, xl)
 - feat(Input): Add `daisy_input` alias helper in addition to `daisy_text_input`
 - fix(Link): Tooltips now work correctly
-- fix(Dropdown): Simplify item rendering and add `where:` modifier to relevant CSS classes
+- fix(Dropdown): Simplify item rendering and add `where:` modifier to relevant
+  CSS classes
 - fix(KBD): Accept a simple title
 - fix(Modal): Only show actions part if provided
-- fix(Modal): Remove unnecessary `:dialog` part from component definition ([Fixes #46](https://github.com/profoundry-us/loco_motion/issues/46))
+- fix(Modal): Remove unnecessary `:dialog` part from component definition
+  ([Fixes #46](https://github.com/profoundry-us/loco_motion/issues/46))
 - fix(Navbar): Improved implementation and styling
-- refactor(DocExample): Renamed from `ExampleWrapper` for better semantics and improved code organization
+- refactor(DocExample): Renamed from `ExampleWrapper` for better semantics and
+  improved code organization
 - fix(Fieldset): Fix issue with fieldset textarea rendering
 
 #### Demo / Docs Changes
@@ -227,7 +376,8 @@ Read on for specific changes across the entire project! :tada:
 - fix: Padding issue with ThemeController
 - fix: Issues with swaps (rotation issue remains)
 - fix: Navigation not updating active state on selection
-- fix: Padding issue on Dropdowns example by upgrading to latest Tailwind insiders
+- fix: Padding issue on Dropdowns example by upgrading to latest Tailwind
+  insiders
 - feat: Dark mode toggle functionality
 - fix: Device mockups in dark mode
 - fix: Header and buttons in dark mode
@@ -253,22 +403,30 @@ Read on for specific changes across the entire project! :tada:
 - fix: Border to bottom figure example
 - feat: Standardize H1/H2 doc headings
 - feat: Enhanced navigation with icons, colors, and improved padding
-- add: Algolia search indexing and UI ([Fixes #37](https://github.com/profoundry-us/loco_motion/issues/37))
-- feat(AlgoliaSearch): Add auto-selection of first search result on query for improved UX
-- refactor: Renamed `ExampleWrapper` doc component to `DocExample` for better semantics
-- fix: Converted most uses of code blocks to markdown backticks for improved readability
+- add: Algolia search indexing and UI
+  ([Fixes #37](https://github.com/profoundry-us/loco_motion/issues/37))
+- feat(AlgoliaSearch): Add auto-selection of first search result on query for
+  improved UX
+- refactor: Renamed `ExampleWrapper` doc component to `DocExample` for better
+  semantics
+- fix: Converted most uses of code blocks to markdown backticks for improved
+  readability
 - fix(DocNote): Fix purple TODO variant text color.
 - refactor: Merge `application.js` functionality into `index.js`
 - feat: Add Theme Switcher dropdown to header
 - fix: Fix header item spacing / padding on smaller screens
-- fix: Rename `Data` group to `Data Display` to match component module & DaisyUI 5
+- fix: Rename `Data` group to `Data Display` to match component module & DaisyUI
+  5
 - fix: Make Label docs show better buttons for implementing components
 - fix: Add tooltips to header buttons and make logo a link
 - fix: Always enable BetterErrors in development
 - fix: Header Theme Switcher was using the wrong button size
-- feat: Add soft, outline, and dash style examples to Alert, Badge, and Button examples ([Fixes #36](https://github.com/profoundry-us/loco_motion/issues/36))
-- feat: Updated component documentation to use `@loco_example` tag for better organization
-- add(DocNote): Add new error modifier to doc_note component for improved documentation
+- feat: Add soft, outline, and dash style examples to Alert, Badge, and Button
+  examples ([Fixes #36](https://github.com/profoundry-us/loco_motion/issues/36))
+- feat: Updated component documentation to use `@loco_example` tag for better
+  organization
+- add(DocNote): Add new error modifier to doc_note component for improved
+  documentation
 - fix: Fix issue with figures not showing captions
 - fix: Fix typo in select docs
 - fix: Add check in set_loco_parent_patch to ensure we catch nil references
@@ -336,7 +494,8 @@ made in a new LocoMotion 0.5.0 branch / release.
 
 ### Fixed
 
-- Fixed Button component bug where styles were not always applied with icon options
+- Fixed Button component bug where styles were not always applied with icon
+  options
 - Fixed compatibility issues between the gem and the demo app
 - Fixed Gemfile.lock not getting saved properly during version updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,6 @@ releases** should be considered **breaking**!
 - fix(Theme): Auto-sync the selected theme across every theme selector on the page by watching `change` events and making `setInput` uncheck stale inputs, so a selection in one switcher is no longer silently overridden by another; radio inputs now persist to `localStorage` automatically with no `setTheme` action wiring ([Fixes #115](https://github.com/profoundry-us/loco_motion/issues/115))
 - fix(Theme): Namespace `build_radio_input` ids by input name (`"#{name}-#{theme}"`) to avoid duplicate ids when multiple theme controllers share a page
 
-### Demo/Docs Changes
-
-- fix(demo): Add `ads_preload_script` helper to prevent flash of ads content when page loads
-- fix(demo): Move `ads_preload_script` after ads element in layout since it needs to query for specific DOM elements
-- fix(demo): Add Playwright test to verify ads visibility is set correctly on non-hidden pages
-
 ### General Changes
 
 - chore(Skills): Split `start-issue` into two focused skills: `create-issue`
@@ -65,6 +59,9 @@ releases** should be considered **breaking**!
 
 ### Demo / Docs Changes
 
+- fix(demo): Add `ads_preload_script` helper to prevent flash of ads content when page loads
+- fix(demo): Move `ads_preload_script` after ads element in layout since it needs to query for specific DOM elements
+- fix(demo): Add Playwright test to verify ads visibility is set correctly on non-hidden pages
 - add(Docs): Add missing page titles to Install, LLMs, Docker, HAML, and Debugging pages
 - feat(Join): Update join examples to use `with_button` slot instead of `with_item` for buttons
 - feat(Join): Add expansive direct content example with input, select, and indicator components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ releases** should be considered **breaking**!
 - feat(Configuration): Add comprehensive documentation to Configuration class
 - add(FAB): Add new `Daisy::Actions::FabComponent` (`daisy_fab`) implementing the DaisyUI FAB / Speed Dial pattern with `button`, `activator`, and `action` slots ([Fixes #93](https://github.com/profoundry-us/loco_motion/issues/93))
 - fix(DeviceComponent): Fix tablet mockup for DaisyUI v5 by removing dead `!mt-0` hack and moving sizing to the container via `css:` (override `aspect-ratio`, `max-width`, `border-radius`) instead of `display_css` ([Fixes #99](https://github.com/profoundry-us/loco_motion/issues/99))
+- fix(Theme): Auto-sync the selected theme across every theme selector on the page by watching `change` events and making `setInput` uncheck stale inputs, so a selection in one switcher is no longer silently overridden by another; radio inputs now persist to `localStorage` automatically with no `setTheme` action wiring ([Fixes #115](https://github.com/profoundry-us/loco_motion/issues/115))
+- fix(Theme): Namespace `build_radio_input` ids by input name (`"#{name}-#{theme}"`) to avoid duplicate ids when multiple theme controllers share a page
 
 ### Demo/Docs Changes
 
@@ -59,6 +61,7 @@ releases** should be considered **breaking**!
 - feat(BaseComponent): Improve `build` method to merge build_kws into config before initialize for proper precedence
 - feat(BaseComponent): Update instance variables for build_kws keys after initialize to ensure options like `skip_styling` are available during `setup_component`
 - feat(RadioButton): Move rendering from call method to HAML template to match CheckboxComponent pattern
+- chore(justfile): Rename the `*-quick` targets (`all-quick`, `loco-quick`, `demo-quick`, `yard-quick`) to `*-fast`
 
 ### Demo / Docs Changes
 
@@ -81,6 +84,8 @@ releases** should be considered **breaking**!
 - docs(Skills): Add `run-demo` skill for booting the demo Rails app locally without Docker, including Ruby/Node version handling, vendor symlink setup, and the `file:../..` + `--no-lockfile` yarn pattern to avoid polluting `yarn.lock`
 - docs(Skills): Add `screenshot-demo` skill for capturing full-page screenshots and videos of demo pages via Playwright, depending on `run-demo`
 - docs(Skills): Update `create-pr` skill with label-selection guidance and a follow-up `mcp__github__issue_write` step to apply labels after PR creation
+- docs(Theme): Update the Theme Controller "Theme Radio Inputs" example note to document the automatic syncing, and link the preload-script note to the `ThemeHelper` API docs
+- chore(demo): Switch the header version badge to a "View All Releases" tip linking to the GitHub releases page, and remove the stale issue #49 flash-of-content comment
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,13 @@ daisy_button(color: :primary, size: :lg)
 
 ## Markdown / Documentation
 
-- Wrap lines at 80 characters.
+- Wrap lines at 80 characters. This includes `CHANGELOG.md` entries — wrap
+  every description and indent continuation lines to align with the text after
+  the list marker (2 spaces under a top-level `- `, 4 under a nested `  - `).
+- Never split an inline code span (`` `...` ``), a Markdown link
+  (`[text](url)`), or a `<code>` tag across lines. A line may exceed 80
+  characters only when one such unbreakable token is itself too long; prose
+  must always wrap.
 - Add a newline after every header.
 - Use two newlines before H1 headings.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,13 +143,15 @@ daisy_button(color: :primary, size: :lg)
 
 ## Markdown / Documentation
 
-- Wrap lines at 80 characters. This includes `CHANGELOG.md` entries — wrap
-  every description and indent continuation lines to align with the text after
-  the list marker (2 spaces under a top-level `- `, 4 under a nested `  - `).
+- Wrap lines at 80 characters.
+- Exception: wrap `CHANGELOG.md` entries at 110 characters — the longer limit
+  keeps each entry readable. Indent continuation lines to align with the text
+  after the list marker (2 spaces under a top-level `- `, 4 under a nested
+  `  - `).
 - Never split an inline code span (`` `...` ``), a Markdown link
-  (`[text](url)`), or a `<code>` tag across lines. A line may exceed 80
-  characters only when one such unbreakable token is itself too long; prose
-  must always wrap.
+  (`[text](url)`), or a `<code>` tag across lines. A line may exceed its limit
+  only when one such unbreakable token is itself too long; prose must always
+  wrap.
 - Add a newline after every header.
 - Use two newlines before H1 headings.
 

--- a/app/components/daisy/actions/theme_controller.js
+++ b/app/components/daisy/actions/theme_controller.js
@@ -18,8 +18,14 @@ export default class extends Controller {
     // Setup a custom listener to watch for changes on the page in case the
     // page has multiple theme selectors
     this.storageChangeListener = this.storageChanged.bind(this)
-
     window.addEventListener('localstorage-update', this.storageChangeListener)
+
+    // Automatically persist + sync whenever a theme input within this
+    // controller changes. This means consumers do NOT need to wire up a
+    // `setTheme` action on each radio/checkbox — simply changing the input is
+    // enough to save the theme and keep every other selector in sync.
+    this.inputChangeListener = this.handleInputChange.bind(this)
+    this.element.addEventListener('change', this.inputChangeListener)
   }
 
   /**
@@ -28,19 +34,22 @@ export default class extends Controller {
    */
   disconnect() {
     window.removeEventListener('localstorage-update', this.storageChangeListener)
+    this.element.removeEventListener('change', this.inputChangeListener)
   }
 
   /**
-   * Sets the appropriate radio input as checked based on the current theme.
-   * This ensures the UI reflects the active theme.
+   * Syncs the radio inputs within this controller to the current theme.
+   * The input matching the active theme is checked and every other
+   * theme-controller input is unchecked, so a selection made in one selector
+   * never leaves a stale `:checked` input behind in another.
    */
   setInput() {
     const theme = this.getCurrentTheme()
-    const input = this.element.querySelector(`input[value='${theme}']`);
+    const inputs = this.element.querySelectorAll('input.theme-controller')
 
-    if (input) {
-      input.checked = true;
-    }
+    inputs.forEach((input) => {
+      input.checked = input.value === theme
+    })
   }
 
   /**
@@ -77,19 +86,54 @@ export default class extends Controller {
    * Changes the theme based on user selection.
    * Updates localStorage and dispatches a custom event to notify other controllers.
    *
+   * Supports two markup patterns:
+   *   1. The action is placed on a wrapper element that contains an `<input>`
+   *      (e.g. the Custom Switcher's `<a>` links).
+   *   2. The action is placed directly on the `<input>` itself.
+   *
    * @param {Event} event - The triggering click event
    */
   setTheme(event) {
-    const input = event.currentTarget.querySelector('input')
+    const target = event.currentTarget
+    const input = target.matches && target.matches('input')
+      ? target
+      : target.querySelector('input')
 
     if (input) {
-      localStorage.setItem("savedTheme", input.value)
-
-      const updateEvent = new CustomEvent('localstorage-update', { detail: { key: 'savedTheme', newValue: input.value } })
-      window.dispatchEvent(updateEvent)
+      this.applyTheme(input.value)
     }
 
-    event.preventDefault();
+    event.preventDefault()
+  }
+
+  /**
+   * Handles `change` events bubbling up from any theme-controller input within
+   * this controller. Persists and broadcasts the newly selected theme so every
+   * other selector stays in sync — no per-input action wiring required.
+   *
+   * @param {Event} event - The triggering change event
+   */
+  handleInputChange(event) {
+    const input = event.target
+
+    if (!input || !input.classList || !input.classList.contains('theme-controller')) return
+    if (!input.checked) return
+
+    this.applyTheme(input.value)
+  }
+
+  /**
+   * Persists the given theme, applies it to the document, and notifies every
+   * other theme controller on the page so they can sync their inputs.
+   *
+   * @param {string} value - The theme name to apply
+   */
+  applyTheme(value) {
+    localStorage.setItem("savedTheme", value)
+    document.documentElement.setAttribute('data-theme', value)
+
+    const updateEvent = new CustomEvent('localstorage-update', { detail: { key: 'savedTheme', newValue: value } })
+    window.dispatchEvent(updateEvent)
   }
 
   /**

--- a/app/components/daisy/actions/theme_controller_component.rb
+++ b/app/components/daisy/actions/theme_controller_component.rb
@@ -54,7 +54,11 @@ class Daisy::Actions::ThemeControllerComponent < LocoMotion::BaseComponent
   #
   def build_radio_input(theme, **options)
     options[:css] = (options[:css] || "").concat(" theme-controller")
-    default_options = { name: "theme", id: "theme-#{theme}", value: theme }
+
+    # Namespace the id by the input name so multiple theme controllers can
+    # coexist on the same page without generating duplicate ids.
+    name = options[:name] || "theme"
+    default_options = { name: name, id: "#{name}-#{theme}", value: theme }
 
     render Daisy::DataInput::RadioButtonComponent.new(**default_options.deep_merge(options))
   end

--- a/app/helpers/daisy/theme_helper.rb
+++ b/app/helpers/daisy/theme_helper.rb
@@ -8,7 +8,7 @@ module Daisy
     # to prevent a flash of content when the page loads.
     #
     # This script runs synchronously in the head section before the page
-    # renders, setting the data-theme attribute on the html element if a
+    # renders, setting the `data-theme` attribute on the html element if a
     # theme has been saved in localStorage.
     #
     # @return [String] The inline script as a string

--- a/docs/demo/app/views/application/_header.html.haml
+++ b/docs/demo/app/views/application/_header.html.haml
@@ -10,8 +10,9 @@
           %em> Loco
           %span.font-bold Motion
 
-    = link_to "https://github.com/profoundry-us/loco_motion/", target: "_blank", class: "flex items-center ml-2" do
-      = daisy_button("v#{LocoMotion::VERSION}", css: "px-4 tooltip tooltip-right btn-info btn-soft btn-xs rounded-full")
+    = daisy_tip("View All Releases", css: "tooltip-info tooltip-bottom md:tooltip-right") do
+      = daisy_button("v#{LocoMotion::VERSION}", css: "ml-2 px-4 btn-info btn-soft btn-xs rounded-full",
+        href: "https://github.com/profoundry-us/loco_motion/releases", target: "_blank")
 
   - bar.with_end(css: "w-auto! space-x-2") do
     = daisy_button(css: "btn-sm px-3 sm:px-6 rounded-full", html: { onclick: "javascript:showDocSearch()" }) do
@@ -22,10 +23,6 @@
         = hero_icon "magnifying-glass", css: "size-3.5"
         Search
 
-    - # Bug: There is a slight delay so the search bar and a few other
-    - # components may flash before the theme is set.
-    - #
-    - # https://github.com/profoundry-us/loco_motion/issues/49
     - button_css = "flex! btn-sm btn-ghost px-1 sm:px-3 max-lg:tooltip max-lg:tooltip-left max-lg:tooltip-secondary"
 
     = daisy_theme_controller do |tc|

--- a/docs/demo/app/views/examples/daisy/actions/theme_controllers.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/theme_controllers.html.haml
@@ -17,7 +17,9 @@
       sub-components, whereas typical components use the HAML `-` syntax to
       "pass" the component to a slot.
 
-  = doc_note(modifier: :tip) do
+  - theme_helper_docs_url = "#{Rails.configuration.api_docs_host}/Daisy/ThemeHelper#theme_preload_script-instance_method"
+  - theme_helper_docs_link = daisy_link(href: theme_helper_docs_url, target: "_blank", title: "ThemeHelper API Docs")
+  = doc_note(modifier: :warning, css: "mt-8") do
     :markdown
       To prevent a flash of content when the page loads with a non-default
       theme, add `= theme_preload_script` to your layout's `<head>` section.
@@ -25,7 +27,7 @@
       localStorage.
 
       See [GitHub Issue #49](https://github.com/profoundry-us/loco_motion/issues/49)
-      for more details.
+      and the #{theme_helper_docs_link} for more details.
 
 
 = doc_example(title: "Theme Preview Icons") do |doc|
@@ -47,17 +49,18 @@
 = doc_example(title: "Theme Radio Inputs") do |doc|
   - doc.with_description do
     :markdown
-      When a theme radio input is selected, the theme's page will change to the
-      value of the the input.
+      When a theme radio input is selected, the page's theme will change to the
+      value of the input.
 
-    = doc_note(modifier: :warning, css: "mb-8") do
+    = doc_note(modifier: :tip, css: "mb-8") do
       :markdown
-        We provide a custom name of `docs-radio-theme` so that this example
-        doesn't interfere with the header theme or other examples.
+        You do **not** need to wire up any `setTheme` action. The
+        `ThemeController` automatically watches its inputs for `change` events,
+        saves the selection to `localStorage`, and keeps every other theme
+        selector on the page (including the header switcher) in sync.
 
-        However, because we are **only** using the radio inputs, we do **NOT**
-        call the `setTheme()` method, and thus we do **NOT** save these changes
-        to `localStorage`.
+        We provide a custom name of `docs-radio-theme` so these inputs form
+        their own radio group, but selecting one still syncs everywhere.
 
   = daisy_theme_controller do |theme_controller|
     .flex.flex-col.sm:flex-row.gap-4.items-start.sm:items-center

--- a/docs/demo/e2e/daisy/actions/theme_controllers.spec.ts
+++ b/docs/demo/e2e/daisy/actions/theme_controllers.spec.ts
@@ -37,3 +37,62 @@ test('clear theme removes data-theme attribute', async ({ page }) => {
   // Verify the data-theme attribute is removed without page refresh
   await expect(page.locator('html')).not.toHaveAttribute('data-theme');
 });
+
+const PAGE = '/examples/Daisy::Actions::ThemeControllerComponent';
+
+// Fingerprint of the active theme: DaisyUI assigns each theme a distinct
+// --color-primary on :root, so this tells us which theme is *visually* applied.
+const appliedPrimary = (page) =>
+  page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim()
+  );
+
+// Values of every currently-checked theme-controller input, across all groups.
+const checkedThemeValues = (page) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll('input.theme-controller:checked')).map((i: any) => i.value)
+  );
+
+test('radio theme selection syncs everywhere and persists, even after another switcher was used', async ({ page }) => {
+  await page.goto(PAGE);
+  await page.evaluate(() => localStorage.removeItem('savedTheme'));
+
+  // Capture the "light" theme fingerprint by selecting it in the radio demo.
+  const lightRadio = page.locator('input[name="docs-radio-theme"][value="light"]');
+  await lightRadio.check({ force: true });
+  const lightPrimary = await appliedPrimary(page);
+
+  // Select "cyberpunk" via the header "Themes" dropdown (a *different* switcher).
+  // This is the exact scenario from the bug report.
+  await page.locator('[data-tip="Themes"]').click();
+  await page.locator('[data-action*="setTheme"]:has(input[name="docs-theme"][value="cyberpunk"])').click();
+  await expect.poll(() => appliedPrimary(page)).not.toBe(lightPrimary); // cyberpunk is now applied
+
+  // Re-select "light" in the radio demo. "light" is EARLIER than "cyberpunk" in
+  // the theme list, so before the fix the stale cyberpunk inputs in the other
+  // groups override it and nothing changes.
+  await lightRadio.check({ force: true });
+
+  // The radio selection must actually take effect on the page...
+  await expect.poll(() => appliedPrimary(page)).toBe(lightPrimary);
+
+  // ...persist to localStorage without any explicit setTheme wiring on the radio...
+  expect(await page.evaluate(() => localStorage.getItem('savedTheme'))).toBe('light');
+
+  // ...and sync every other switcher so no stale checked input remains.
+  expect([...new Set(await checkedThemeValues(page))].sort()).toEqual(['light']);
+});
+
+test('theme-controller inputs have unique ids', async ({ page }) => {
+  await page.goto(PAGE);
+
+  const duplicateIds = await page.evaluate(() => {
+    const counts: Record<string, number> = {};
+    document.querySelectorAll('input.theme-controller').forEach((i: any) => {
+      counts[i.id] = (counts[i.id] || 0) + 1;
+    });
+    return Object.entries(counts).filter(([, n]) => n > 1).map(([id, n]) => `${id} (x${n})`);
+  });
+
+  expect(duplicateIds, 'each theme-controller input should have a unique id').toEqual([]);
+});

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ all:
     docker compose up --build
 
 # Run all of the containers without rebuilding
-all-quick:
+all-fast:
     docker compose up
 
 # Run all of the tests (uses running containers)
@@ -56,7 +56,7 @@ loco:
     docker compose up loco --build
 
 # Run the loco container without rebuilding
-loco-quick:
+loco-fast:
     docker compose up loco
 
 # Open a Ruby console in the loco container
@@ -81,7 +81,7 @@ demo:
     docker compose up demo --build
 
 # Run the demo container without rebuilding
-demo-quick:
+demo-fast:
     docker compose up demo
 
 # Open a Ruby console in the demo container
@@ -145,7 +145,7 @@ yard-clean:
     rm -rf .yardoc
 
 # Run the yard container without building
-yard-quick:
+yard-fast:
     docker compose up yard
 
 # Open a bash shell in the running yard container

--- a/spec/components/daisy/actions/theme_controller_component_spec.rb
+++ b/spec/components/daisy/actions/theme_controller_component_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe Daisy::Actions::ThemeControllerComponent, type: :component do
         
         def build_radio_input(theme, **options)
           options[:css] = (options[:css] || "").concat(" theme-controller")
-          default_options = { name: "theme", id: "theme-#{theme}", value: theme }
-          
+          name = options[:name] || "theme"
+          default_options = { name: name, id: "#{name}-#{theme}", value: theme }
+
           mock_render(Daisy::DataInput::RadioButtonComponent, **default_options.deep_merge(options))
         end
         
@@ -75,10 +76,17 @@ RSpec.describe Daisy::Actions::ThemeControllerComponent, type: :component do
       
       it "allows overriding options" do
         result = component.build_radio_input(test_theme, css: "custom-class", checked: true)
-        
+
         expect(result[:args][:css]).to include("custom-class")
         expect(result[:args][:css]).to include("theme-controller")
         expect(result[:args][:checked]).to be true
+      end
+
+      it "namespaces the id by the input name to avoid duplicate ids" do
+        result = component.build_radio_input(test_theme, name: "docs-radio-theme")
+
+        expect(result[:args][:name]).to eq("docs-radio-theme")
+        expect(result[:args][:id]).to eq("docs-radio-theme-#{test_theme}")
       end
     end
     


### PR DESCRIPTION
## Context

When the Theme Controller is used with more than one theme selector on a page
(for example the header dropdown plus the on-page radio demo), selecting a
theme in one selector could be silently overridden by another. After picking a
theme from a dropdown, clicking a theme that appears *earlier* in the theme
list within the radio demo did nothing, while later themes still worked.

The root cause: each selector is its own radio group, so a selection in one
group never unchecked the matching <code>.theme-controller</code> input in the
other groups. DaisyUI applies a theme whenever **any**
<code>.theme-controller[value=X]:checked</code> exists and resolves multiple
checked inputs by **CSS source order**, so a stale checked input from another
group won the cascade. This is the bug behind #115 (the original issue
described a related but different localStorage scenario).

## Description

- <code>app/components/daisy/actions/theme_controller.js</code> — the controller
  now watches <code>change</code> events on its element, so changing any theme
  input automatically persists to <code>localStorage</code> and broadcasts to
  every other controller. No <code>setTheme</code> action wiring is needed on
  radio inputs.
- <code>setInput</code> is now authoritative: it checks the matching input and
  **unchecks every other** <code>theme-controller</code> input, so no stale
  <code>:checked</code> input can override a new selection.
- Extracted a shared <code>applyTheme(value)</code> helper (sets
  <code>localStorage</code>, the <code>data-theme</code> attribute, and
  dispatches <code>localstorage-update</code>); hardened <code>setTheme</code>
  to work whether the action sits on a wrapper or directly on an input.
- <code>app/components/daisy/actions/theme_controller_component.rb</code> —
  <code>build_radio_input</code> now namespaces ids as
  <code>"#{name}-#{theme}"</code> so multiple controllers can coexist without
  duplicate ids (the default-name case stays <code>theme-#{theme}</code>).
- Added Playwright coverage in
  <code>docs/demo/e2e/daisy/actions/theme_controllers.spec.ts</code>
  reproducing the sync bug and asserting unique ids, plus an RSpec example for
  the namespaced id.
- Updated the demo example note, the header version badge, and a few docs /
  tooling tweaks.

## Related Issues

Fixes #115

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)
