### PR TITLE
fix(demo): Restore plain-Ruby guard in bin/bundle binstub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   syncing, and link the preload-script note to the `ThemeHelper` API docs
 - chore(demo): Switch the header version badge to a "View All Releases" tip linking to the GitHub releases
   page, and remove the stale issue #49 flash-of-content comment
+- fix(demo): Restore plain-Ruby guard in `docs/demo/bin/bundle` — `.present?` (ActiveSupport) is not
+  available when the binstub runs, causing a `NoMethodError` on Heroku during `bundle install`
 
 ### Changed
 

--- a/docs/demo/bin/bundle
+++ b/docs/demo/bin/bundle
@@ -39,7 +39,7 @@ m = Module.new do
 
   def gemfile
     gemfile = ENV["BUNDLE_GEMFILE"]
-    return gemfile if gemfile.present?
+    return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path("../Gemfile", __dir__)
   end


### PR DESCRIPTION
## Context

`docs/demo/bin/bundle` uses `.present?` (an ActiveSupport method) as a guard
on the `BUNDLE_GEMFILE` environment variable. This binstub runs before Rails or
ActiveSupport loads, so `.present?` is undefined — raising `NoMethodError` and
blocking `bundle install` on Heroku. Introduced in PR #118 when RuboCop-style
cleanup replaced the plain-Ruby guard with the Rails idiom.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Revert `gemfile.present?` → `gemfile && !gemfile.empty?` in
  <code>docs/demo/bin/bundle</code>
- `.present?` is an ActiveSupport method that is not available when the
  binstub executes, before Rails has loaded

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [ ] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)