### PR TITLE
fix(Tooltip): Reveal `tip:` tooltips on keyboard focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 
 ### Components Changes
 
+- fix(Tooltip): Reveal `tip:` tooltips on keyboard focus. DaisyUI 5 only shows focus tooltips when the
+  focusable element is a child of `.tooltip`, so tooltips applied via `tip:` appeared on hover but not on
+  focus. The demo now ships a `.tooltip:focus-visible` rule and the Getting Started guide documents it for
+  your own app ([Fixes #116](https://github.com/profoundry-us/loco_motion/issues/116)).
 - fix(Breadcrumbs): Call `super` in `before_render` so the `IconableComponent` and `TippableComponent` setup hooks
   run — breadcrumb item `tip:` tooltips and icons were silently dropped before.
 - fix(Rating, TimelineEvent, Steps, Dock): Call `super` in `before_render` overrides so concern setup hooks are no

--- a/docs/demo/app/assets/stylesheets/application.tailwind.css
+++ b/docs/demo/app/assets/stylesheets/application.tailwind.css
@@ -32,3 +32,21 @@
 .prose {
   max-width: var(--max-prose-width);
 }
+
+/*
+ * Reveal tooltips on keyboard focus when the `tooltip` class is applied
+ * directly to a focusable element (e.g. via LocoMotion's `tip:` attribute on a
+ * button or link). DaisyUI v5 only reveals tooltips through `:has(:focus-visible)`,
+ * which requires the focused element to be a *descendant* of `.tooltip` — so a
+ * tooltip placed on the element itself never appears on focus. This mirrors
+ * DaisyUI's own reveal rule for when the tooltip element itself is focus-visible.
+ * See the Getting Started guide for details.
+ */
+.tooltip:focus-visible:is([data-tip]:not([data-tip=""]), :has(.tooltip-content:not(:empty))) {
+  &[data-tip]::before,
+  &::after,
+  & > .tooltip-content {
+    opacity: 1;
+    --tt-pos: 0rem;
+  }
+}

--- a/docs/demo/app/views/examples/daisy/feedback/tooltips.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/tooltips.html.haml
@@ -19,6 +19,14 @@
     component, or any block of HTML, in a tooltip. This is also aliased as
     `daisy_tip` for convenience.
 
+= doc_note(modifier: :note, title: "Keyboard Focus", css: "mt-6 max-w-2xl") do
+  :markdown
+    The `tip` attribute reveals the tooltip on **hover**. To also show it when
+    a keyboard user tabs to the element, add the small CSS rule from the
+    [Getting Started guide](#{guide_path("getting_started")}) — DaisyUI only
+    reveals focus tooltips when the focusable element sits *inside* the
+    `.tooltip`, which the `daisy_tooltip` wrapper does for you.
+
 
 = doc_example(title: "Component Tooltips") do |doc|
   - doc.with_description do

--- a/docs/demo/app/views/guides/01_getting_started.html.haml
+++ b/docs/demo/app/views/guides/01_getting_started.html.haml
@@ -225,6 +225,41 @@
 
 .mt-12.prose
   :markdown
+    ### Reveal Tooltips on Keyboard Focus
+
+    LocoMotion lets you attach a tooltip to many components with the `tip:`
+    attribute, which adds the `tooltip` class and `data-tip` directly to the
+    element. DaisyUI 5, however, only reveals a tooltip on keyboard focus when
+    the focused element is a **child** of the `.tooltip` element — so tooltips
+    placed directly on a focusable element (a button, link, etc.) show on hover
+    but not when a keyboard user tabs to them.
+
+    Add this small rule to your `application.tailwind.css` so those tooltips
+    also appear on focus. It mirrors DaisyUI's own reveal rule for the case
+    where the tooltip element itself is focused:
+
+.mt-6.max-w-prose
+  = doc_code(language: "css") do
+    :plain
+      /* Reveal `tip:`/`tooltip` tooltips on keyboard focus */
+      .tooltip:focus-visible:is([data-tip]:not([data-tip=""]), :has(.tooltip-content:not(:empty))) {
+        &[data-tip]::before,
+        &::after,
+        & > .tooltip-content {
+          opacity: 1;
+          --tt-pos: 0rem;
+        }
+      }
+
+= doc_note(modifier: :note, title: "Prefer Wrapping?", css: "mt-6") do
+  :markdown
+    If you'd rather not add custom CSS, wrap the element in the
+    `daisy_tooltip` (aliased `daisy_tip`) component instead. That follows
+    DaisyUI's recommended structure — the focusable element becomes a child of
+    the `.tooltip`, so focus works without any extra rule.
+
+.mt-12.prose
+  :markdown
     ## 7. Try It Out!
 
     With everything installed, let's confirm it all works. First, tell the

--- a/docs/demo/e2e/daisy/feedback/tooltips.spec.ts
+++ b/docs/demo/e2e/daisy/feedback/tooltips.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { loco } from '../../spec_helpers';
 
 test('page loads', async ({ page }) => {
@@ -13,4 +13,26 @@ test('page loads', async ({ page }) => {
     'Component Tooltips',
     'Wrapper Tooltips'
   ]);
+});
+
+test('tip tooltips reveal on keyboard focus', async ({ page }) => {
+  await page.goto('/examples/Daisy::Feedback::TooltipComponent');
+
+  // A tooltip applied directly to a focusable element via the `tip:` attribute.
+  const button = page.locator('button.tooltip[data-tip="This is a tooltip!"]');
+  await expect(button).toHaveCount(1);
+
+  // The tooltip bubble is the `::before` pseudo-element; its opacity tells us
+  // whether the tooltip is visible.
+  const bubbleOpacity = () =>
+    button.evaluate((el) => getComputedStyle(el, '::before').opacity);
+
+  // Hidden by default, revealed on focus, hidden again on blur.
+  expect(await bubbleOpacity()).toBe('0');
+
+  await button.focus();
+  await expect.poll(bubbleOpacity).toBe('1');
+
+  await button.evaluate((el) => (el as HTMLButtonElement).blur());
+  await expect.poll(bubbleOpacity).toBe('0');
 });


### PR DESCRIPTION
## Context

Tooltips added via the `tip:` attribute (the `TippableComponent` concern) showed
on hover but never on **keyboard focus**. The `tip:` shortcut applies the
`tooltip` class and `data-tip` directly to the focusable element:

```html
<button class="btn tooltip btn-primary" data-tip="This is a tooltip!">Hover Me</button>
```

DaisyUI 5 only reveals tooltips on focus through `&:has(:focus-visible)`, which
requires the focused element to be a **descendant** of `.tooltip`. Since the
button *is* the `.tooltip` element, there is nothing to match, so focus never
reveals it. The `daisy_tooltip` wrapper works because the focusable element is a
child of `.tooltip`.

This is by design in DaisyUI — its canonical v5 pattern is wrapping, so there is
no upstream fix coming and LocoMotion has to resolve it. The fix is a small CSS
rule that mirrors DaisyUI's own reveal rule for when the tooltip element itself
is `:focus-visible`. It uses `:focus-visible` (keyboard only) so tooltips don't
stick after a mouse click.

## Related Issues

Fixes #116

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [x] Test update/addition
- [ ] Other (please describe):

## Description

- **`docs/demo/app/assets/stylesheets/application.tailwind.css`** — Add a
  `.tooltip:focus-visible` reveal rule (mirrors DaisyUI's own reveal rule) so a
  tooltip applied directly to a focusable element appears on keyboard focus.
- **`docs/demo/app/views/guides/01_getting_started.html.haml`** — Document the
  CSS snippet, plus a "prefer wrapping?" note, so library consumers can opt in
  (the gem ships no CSS, so this must live in consumer setup).
- **`docs/demo/app/views/examples/daisy/feedback/tooltips.html.haml`** — Add a
  "Keyboard Focus" note pointing readers to the Getting Started guide.
- **`docs/demo/e2e/daisy/feedback/tooltips.spec.ts`** — Add a regression test
  asserting the `tip:` tooltip reveals on focus and hides on blur.
- **`CHANGELOG.md`** — Add a `fix(Tooltip)` entry.

## Checklist
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Verified end-to-end on the running demo by measuring the tooltip bubble
(`::before`) opacity in Chromium:

| Pattern | idle | focus | hover |
|---|---|---|---|
| `tip:` on button — before fix | 0 | **0** | 1 |
| `tip:` on button — after fix | 0 | **1** | 1 |

Test results:
- Playwright `e2e/daisy/feedback/tooltips.spec.ts` — 2 passed (page loads +
  new focus regression test).
- RSpec `tooltip_component_spec` + `tippable_component_spec` — 24 examples, 0
  failures.

No Ruby/component code changed, so the `tip:` API is unchanged; this is purely a
CSS reveal rule plus docs and a test.
