### PR TITLE
chore(Archon): Add custom workflow tooling for component development

### DIFF
--- a/.archon/commands/loco-document-component.md
+++ b/.archon/commands/loco-document-component.md
@@ -1,0 +1,50 @@
+---
+description: Add complete YARD documentation to the newly implemented component.
+argument-hint: (no arguments — reads $ARTIFACTS_DIR/naming.json and plan.md)
+---
+
+# Document the New Component (YARD)
+
+**Workflow ID**: $WORKFLOW_ID
+
+The `document-component` skill is preloaded. The previous step implemented the
+component without docs; your ONLY job is to add complete YARD documentation.
+
+## Phase 1: LOAD
+
+1. Read `$ARTIFACTS_DIR/naming.json` and `$ARTIFACTS_DIR/plan.md`.
+2. Read the implemented component class and HAML template.
+3. Read 1–2 well-documented components in the same group as references for
+   tone and depth.
+
+## Phase 2: DOCUMENT
+
+Follow the `document-component` skill:
+
+- Class-level order: description → `@note` → `@part` → `@slot` →
+  `@loco_example`.
+- Use `@loco_example` (NOT `@example`); examples in HAML with `daisy_` helpers.
+- Document every `define_part` with `@part` and every slot with `@slot`.
+- Put ALL `@param`/`@option` tags on `initialize`, blank line between each.
+- Wrap doc lines at 80 characters.
+- Documentation ONLY — do not change behavior. If you spot a real bug, note it
+  in the report instead of fixing it here.
+
+## Phase 3: SELF-CHECK
+
+Docs are comments, but a stray character can still break the file. Re-run the
+component's spec:
+
+```bash
+docker compose exec -T loco bundle exec rspec spec/components/daisy/{component_group}/{component_name}_component_spec.rb
+```
+
+### PHASE_3_CHECKPOINT
+- [ ] Class docs in the required order; `@loco_example` used throughout
+- [ ] Every part, slot, and param documented; lines wrapped at 80 chars
+- [ ] No behavior changes; the component's spec still passes
+
+## Phase 4: REPORT
+
+Append a short "Documentation" section to `$ARTIFACTS_DIR/implementation.md`
+(what was documented, example count). Reply with a 2–3 line summary.

--- a/.archon/commands/loco-e2e-component.md
+++ b/.archon/commands/loco-e2e-component.md
@@ -16,7 +16,10 @@ page and make it pass.
 2. Read the demo example view:
    `docs/demo/app/views/examples/daisy/{component_group}/{plural_name}.html.haml`
    — your tests mirror its `doc_example` blocks.
-3. Read one existing e2e spec in `docs/demo/e2e/daisy/` as a style template.
+3. Read THREE existing e2e specs in `docs/demo/e2e/daisy/` as style templates —
+   prefer specs from the same component group when available. Three reveal the
+   shared conventions (structure, selectors, assertions) rather than one
+   author's quirks.
 
 ## Phase 2: WRITE
 

--- a/.archon/commands/loco-e2e-component.md
+++ b/.archon/commands/loco-e2e-component.md
@@ -1,0 +1,57 @@
+---
+description: Write and run a Playwright e2e test for the new component's demo page.
+argument-hint: (no arguments — reads $ARTIFACTS_DIR/naming.json)
+---
+
+# Playwright E2E for the New Component
+
+**Workflow ID**: $WORKFLOW_ID
+
+The `playwright-tests` skill is preloaded. Add a focused e2e test for the demo
+page and make it pass.
+
+## Phase 1: LOAD
+
+1. Read `$ARTIFACTS_DIR/naming.json` for `component_group` and `plural_name`.
+2. Read the demo example view:
+   `docs/demo/app/views/examples/daisy/{component_group}/{plural_name}.html.haml`
+   — your tests mirror its `doc_example` blocks.
+3. Read one existing e2e spec in `docs/demo/e2e/daisy/` as a style template.
+
+## Phase 2: WRITE
+
+Create `docs/demo/e2e/daisy/{component_group}/{plural_name}.spec.ts`, mirroring
+the example file's directory structure. Write one `test(...)` per `doc_example`
+block — assert the component's key DaisyUI classes/elements are visible on the
+page `/examples/daisy/{component_group}/{plural_name}`. Keep each test to a
+single golden path.
+
+## Phase 3: RUN
+
+The demo app reloads from the mounted source, but ensure it picked up the new
+route first:
+
+```bash
+touch docs/demo/tmp/restart.txt
+```
+
+Then run ONLY this spec inside the demo container (TTY-safe form; the `just`
+target uses `-it` which fails in non-interactive runs):
+
+```bash
+docker compose exec -T demo yarn playwright test 'e2e/daisy/{component_group}/{plural_name}.spec.ts' --reporter=dot --workers=1
+```
+
+Iterate until the spec passes. If the page genuinely cannot render (a real
+component bug), fix the component — but never weaken an assertion just to make
+it green.
+
+### PHASE_3_CHECKPOINT
+- [ ] Spec file created at the mirrored e2e path
+- [ ] One test per demo example
+- [ ] `playwright test ... --reporter=dot --workers=1` passes
+
+## Phase 4: REPORT
+
+Write the pass/fail result to `$ARTIFACTS_DIR/validation.md` (append; note "e2e:
+PASS/FAIL" and any caveat). Reply with a one-line summary.

--- a/.archon/commands/loco-implement-component.md
+++ b/.archon/commands/loco-implement-component.md
@@ -1,5 +1,5 @@
 ---
-description: Implement the real component logic, template, spec, demo, and YARD docs from the plan.
+description: Implement the real component logic, template, spec, and demo from the plan.
 argument-hint: (no arguments — reads $ARTIFACTS_DIR/plan.md and naming.json)
 ---
 
@@ -7,8 +7,8 @@ argument-hint: (no arguments — reads $ARTIFACTS_DIR/plan.md and naming.json)
 
 **Workflow ID**: $WORKFLOW_ID
 
-The `modify-component` and `document-component` skills are preloaded. Turn the
-stubs into a real, documented component that matches the plan.
+The `modify-component` skill is preloaded. Turn the stubs into a real component
+that matches the plan.
 
 ## Phase 1: LOAD
 
@@ -19,7 +19,9 @@ stubs into a real, documented component that matches the plan.
 
 ## Phase 2: IMPLEMENT
 
-Edit the four component files to match the plan. Keep every related file in sync.
+Edit the four component files to match the plan. Keep every related file in
+sync. Do NOT write the YARD documentation here — the workflow's next step
+(`loco-document-component`) owns that; brief inline comments are fine.
 
 **Component class** (`*_component.rb`):
 - Declare parts with `define_part :name`. NEVER define `part(:component)` and
@@ -42,15 +44,7 @@ Edit the four component files to match the plan. Keep every related file in sync
   `:markdown` block and a working `daisy_{component_name}` invocation.
 - Write real, helpful prose in the descriptions (no TODOs left behind).
 
-## Phase 3: DOCUMENT (YARD)
-
-Add YARD docs per the `document-component` skill:
-- Class-level order: description → `@note` → `@part` → `@slot` → `@loco_example`.
-- Use `@loco_example` (NOT `@example`); examples in HAML with `daisy_` helpers.
-- Put ALL `@param`/`@option` tags on `initialize`, blank line between each.
-- Wrap doc lines at 80 characters.
-
-## Phase 4: SELF-CHECK
+## Phase 3: SELF-CHECK
 
 Run just this component's spec to catch obvious breakage early (the workflow's
 `verify` step runs the full suites next):
@@ -61,13 +55,12 @@ docker compose exec -T loco bundle exec rspec spec/components/daisy/{component_g
 
 Fix anything red. Confirm the total diff is still within 10 files / 500 lines.
 
-### PHASE_4_CHECKPOINT
+### PHASE_3_CHECKPOINT
 - [ ] Class, template, spec, and demo example fully implemented (no TODOs)
-- [ ] YARD docs complete, `@loco_example` used, params on `initialize`
 - [ ] Zero size:/color:/variant params; no `part(:component)` definition
 - [ ] This component's spec passes
 
-## Phase 5: REPORT
+## Phase 4: REPORT
 
 Write `$ARTIFACTS_DIR/implementation.md` summarizing what was built (parts,
 slots, options, demo examples) and the current file/line count of the diff.

--- a/.archon/commands/loco-implement-component.md
+++ b/.archon/commands/loco-implement-component.md
@@ -1,0 +1,74 @@
+---
+description: Implement the real component logic, template, spec, demo, and YARD docs from the plan.
+argument-hint: (no arguments — reads $ARTIFACTS_DIR/plan.md and naming.json)
+---
+
+# Implement the New Component
+
+**Workflow ID**: $WORKFLOW_ID
+
+The `modify-component` and `document-component` skills are preloaded. Turn the
+stubs into a real, documented component that matches the plan.
+
+## Phase 1: LOAD
+
+1. Read `$ARTIFACTS_DIR/naming.json` and `$ARTIFACTS_DIR/plan.md`.
+2. Read the stub files the scaffold step created (class, template, spec, demo).
+3. Read the "style template" component(s) named in the plan and mirror their
+   structure.
+
+## Phase 2: IMPLEMENT
+
+Edit the four component files to match the plan. Keep every related file in sync.
+
+**Component class** (`*_component.rb`):
+- Declare parts with `define_part :name`. NEVER define `part(:component)` and
+  NEVER add `_css`/`_html` properties for parts (BaseComponent handles these).
+- Declare slots with `renders_one` / `renders_many` as planned.
+- Set default tag/CSS/html inside `setup_component`.
+- **No `size:`/`color:`/variant params** — Daisy classes flow through `css:`.
+
+**HAML template** (`*_component.html.haml`):
+- Root is `= part(:component) do`. Render sub-elements with `= part(:name) do`.
+- Keep logic minimal; no business logic in the view.
+
+**RSpec spec** (`*_component_spec.rb`):
+- Mirror the component path. Cover the behaviors listed in the plan: default
+  render, each part/slot, and any option. Use `render_inline` + `have_css`.
+
+**Demo example** (`docs/demo/.../{plural_name}.html.haml`):
+- Keep the `doc_title` block. Replace the single stub `doc_example` with the
+  2–4 `doc_example` blocks from the plan. Each needs a `doc.with_description`
+  `:markdown` block and a working `daisy_{component_name}` invocation.
+- Write real, helpful prose in the descriptions (no TODOs left behind).
+
+## Phase 3: DOCUMENT (YARD)
+
+Add YARD docs per the `document-component` skill:
+- Class-level order: description → `@note` → `@part` → `@slot` → `@loco_example`.
+- Use `@loco_example` (NOT `@example`); examples in HAML with `daisy_` helpers.
+- Put ALL `@param`/`@option` tags on `initialize`, blank line between each.
+- Wrap doc lines at 80 characters.
+
+## Phase 4: SELF-CHECK
+
+Run just this component's spec to catch obvious breakage early (the workflow's
+`verify` step runs the full suites next):
+
+```bash
+docker compose exec -T loco bundle exec rspec spec/components/daisy/{component_group}/{component_name}_component_spec.rb
+```
+
+Fix anything red. Confirm the total diff is still within 10 files / 500 lines.
+
+### PHASE_4_CHECKPOINT
+- [ ] Class, template, spec, and demo example fully implemented (no TODOs)
+- [ ] YARD docs complete, `@loco_example` used, params on `initialize`
+- [ ] Zero size:/color:/variant params; no `part(:component)` definition
+- [ ] This component's spec passes
+
+## Phase 5: REPORT
+
+Write `$ARTIFACTS_DIR/implementation.md` summarizing what was built (parts,
+slots, options, demo examples) and the current file/line count of the diff.
+Then reply with a 3–5 line summary.

--- a/.archon/commands/loco-open-pr.md
+++ b/.archon/commands/loco-open-pr.md
@@ -1,0 +1,99 @@
+---
+description: Commit the work, update the CHANGELOG, and open a DRAFT PR using the repo template.
+argument-hint: (no arguments — reads workflow artifacts)
+---
+
+# Commit + Open Draft PR
+
+**Workflow ID**: $WORKFLOW_ID
+
+The `create-pr` skill is preloaded. Commit the new component and open a **draft**
+PR for the maintainer to review. The full RSpec suites already ran in the
+workflow's `verify` step — do NOT re-run them here unless the diff looks empty.
+
+## Phase 1: GUARD
+
+```bash
+git status --porcelain
+git diff --stat
+```
+
+If there are NO changes and nothing is staged AND the branch has no commits
+ahead of `$BASE_BRANCH`, there is nothing to ship: write a short note to
+`$ARTIFACTS_DIR/validation.md`, skip the rest, and report "no changes — no PR
+created." Otherwise continue.
+
+## Phase 2: LOAD
+
+Read, if present: `$ARTIFACTS_DIR/naming.json`, `$ARTIFACTS_DIR/plan.md`,
+`$ARTIFACTS_DIR/implementation.md`, `$ARTIFACTS_DIR/validation.md`. Use these to
+describe the change and to report the honest test/e2e status.
+
+## Phase 3: CHANGELOG
+
+Add an entry to `CHANGELOG.md` under the `[Unreleased]` section (create the
+section if missing), in the **Component Changes** subsection, describing the new
+component. Wrap CHANGELOG lines at **110** characters; indent continuation lines
+to align with the text after the `- ` marker. Append to the bottom of the
+subsection; do not alter existing entries.
+
+## Phase 4: COMMIT + PUSH
+
+Stage and commit everything with a conventional message (single quotes preserve
+the backticks):
+
+```bash
+git add -A
+git commit -m 'feat({ComponentTitle}): Add {component_name} component
+
+## Changes
+
+### app/components/daisy/{group}/
+- Add the {component_name} component class, template, parts, and YARD docs.
+
+### spec + demo
+- Add the RSpec spec, demo example view, and Playwright e2e test.
+
+### lib/loco_motion/helpers.rb
+- Register the {ClassName}Component.'
+git push -u origin $(git branch --show-current)
+```
+
+## Phase 5: OPEN DRAFT PR
+
+1. Read `.github/pull_request_template.md` and fill every section:
+   - **Context** — why this component was added.
+   - **Related Issues** — link with `Fixes #N` only if the request named an
+     issue; otherwise leave the placeholder note.
+   - **Type of Change** — mark `- [x] Component update/addition` (no spaces).
+   - **Description** — what was built (parts, slots, options, demo examples).
+   - **Checklist** — mark items `[x]` ONLY when true based on the artifacts
+     (tests passed, YARD added, CHANGELOG updated). Leave unverified items `[ ]`.
+   - **Additional Notes** — state the RSpec result and the Playwright e2e
+     result from `validation.md`. If anything is red or skipped, say so plainly.
+   Write the filled template to `$ARTIFACTS_DIR/pr-body.md`.
+2. Confirm the PR is within limits (**<= 10 files, <= 500 changed lines**). If it
+   exceeds either, note it prominently in Additional Notes so the maintainer can
+   split it.
+3. Create the draft PR:
+
+```bash
+gh pr create --draft \
+  --base "$BASE_BRANCH" \
+  --title "feat({ComponentTitle}): Add {ComponentTitle} component" \
+  --body-file "$ARTIFACTS_DIR/pr-body.md"
+```
+
+4. Apply a label if available: `gh pr edit <number> --add-label "enhancement"`
+   (skip silently if the label does not exist — never invent labels).
+
+### PHASE_5_CHECKPOINT
+- [ ] CHANGELOG updated under [Unreleased] › Component Changes
+- [ ] Work committed and branch pushed
+- [ ] Draft PR opened against `$BASE_BRANCH` with the template fully filled
+- [ ] Test/e2e status reported honestly in the PR body
+
+## Phase 6: REPORT
+
+Reply with the PR URL, the file/line counts, and a one-line status (green / has
+caveats). Save the URL to `$ARTIFACTS_DIR/.pr-url`.

--- a/.archon/commands/loco-open-pr.md
+++ b/.archon/commands/loco-open-pr.md
@@ -71,6 +71,9 @@ git push -u origin $(git branch --show-current)
      (tests passed, YARD added, CHANGELOG updated). Leave unverified items `[ ]`.
    - **Additional Notes** — state the RSpec result and the Playwright e2e
      result from `validation.md`. If anything is red or skipped, say so plainly.
+   - **Formatting** — PR descriptions are EXEMPT from the repo's 80-character
+     wrap rule. Write natural flowing paragraphs and let GitHub's interface
+     wrap them; do not hard-wrap the body text.
    Write the filled template to `$ARTIFACTS_DIR/pr-body.md`.
 2. Confirm the PR is within limits (**<= 10 files, <= 500 changed lines**). If it
    exceeds either, note it prominently in Additional Notes so the maintainer can
@@ -84,8 +87,17 @@ gh pr create --draft \
   --body-file "$ARTIFACTS_DIR/pr-body.md"
 ```
 
-4. Apply a label if available: `gh pr edit <number> --add-label "enhancement"`
-   (skip silently if the label does not exist — never invent labels).
+4. Discover the repository's existing labels, then pick the most relevant:
+
+   ```bash
+   gh label list --limit 100
+   ```
+
+   Choose only from what the list returns — for a brand-new component prefer a
+   `new component`-style label if one exists, otherwise the closest fit (e.g.
+   `enhancement`). Apply with `gh pr edit <number> --add-label "<label>"`.
+   Never invent label names; if nothing genuinely fits, apply none and say so
+   in the report.
 
 ### PHASE_5_CHECKPOINT
 - [ ] CHANGELOG updated under [Unreleased] › Component Changes

--- a/.archon/commands/loco-plan-component.md
+++ b/.archon/commands/loco-plan-component.md
@@ -1,0 +1,81 @@
+---
+description: Research a DaisyUI component + the closest existing LocoMotion component and write an implementation plan.
+argument-hint: (no arguments — reads $ARTIFACTS_DIR/naming.json)
+---
+
+# Plan a New LocoMotion Component
+
+**Workflow ID**: $WORKFLOW_ID
+
+You are designing a brand-new DaisyUI ViewComponent for the LocoMotion library.
+Your ONLY job in this step is to produce a precise implementation plan. Do NOT
+create or edit any component files yet.
+
+## Phase 1: LOAD
+
+1. Read `$ARTIFACTS_DIR/naming.json`. It contains the canonical
+   `component_name`, `component_group`, `component_title`, `plural_name`, and
+   `branch_name`. Treat these as authoritative — do not rename anything.
+2. Read `CLAUDE.md` (repo root) for the component conventions, and skim
+   `lib/loco_motion/helpers.rb` to see how components in this group are
+   registered.
+
+## Phase 2: RESEARCH
+
+1. **DaisyUI markup** — Determine the canonical DaisyUI HTML structure and CSS
+   class names for this component. Prefer `WebFetch` on
+   `https://daisyui.com/components/{component_name}/` (try singular and a couple
+   obvious variants). If the page is unavailable, fall back to your knowledge of
+   DaisyUI 5. Capture the base class, any element/modifier classes, and the
+   expected nesting.
+2. **Closest existing component** — Glob `app/components/daisy/**/*_component.rb`
+   and pick the 1–2 existing components most structurally similar to this one
+   (same group when possible). Read their `.rb`, `.html.haml`, spec, and demo
+   example. These are your style template — mirror their patterns exactly.
+
+## Phase 3: DESIGN
+
+Decide the component's Ruby API. Honor these HARD rules:
+
+- **No `size:`, `color:`, or other visual-variant params.** Users pass DaisyUI
+  classes through the `css:` kwarg. Do not invent variant options.
+- Use `define_part :name` for sub-elements that need their own css/html.
+- NEVER plan a `part(:component)` definition or `_css`/`_html` props for parts —
+  `BaseComponent` handles those.
+- Slots: `renders_one :name, "ComponentClass"` / `renders_many :names, ...`.
+- Keep it small. One component, one concern. The whole PR must stay within
+  **10 files and 500 changed lines**.
+
+## Phase 4: GENERATE
+
+Write `$ARTIFACTS_DIR/plan.md` containing:
+
+1. **Naming table** — component_name, component_group, ModuleName (PascalCase of
+   group), ClassName (PascalCase of name), plural_name, component_title, plus
+   the human-readable group display string used in helpers.rb (e.g. `actions` →
+   `"Actions"`, `data_display` → `"Data Display"`).
+2. **File paths** — the exact 6 paths to be created/edited:
+   - `app/components/daisy/{group}/{name}_component.rb`
+   - `app/components/daisy/{group}/{name}_component.html.haml`
+   - `spec/components/daisy/{group}/{name}_component_spec.rb`
+   - `docs/demo/app/views/examples/daisy/{group}/{plural_name}.html.haml`
+   - `lib/loco_motion/helpers.rb` (registration entry)
+   - `CHANGELOG.md`
+3. **Reference markup** — the DaisyUI HTML + class names you found.
+4. **Style template** — which existing component(s) to mirror, with their paths.
+5. **Proposed API** — the parts (`define_part`), slots, initializer options, the
+   default tag/CSS the component sets in `setup_component`, and whether a
+   Stimulus JS controller is needed (most components need none).
+6. **Demo examples** — a short list (2–4) of `doc_example` blocks to showcase
+   (basic usage + the most useful variations), each described in one line.
+7. **Spec coverage** — the behaviors the RSpec spec must assert.
+
+### PHASE_4_CHECKPOINT
+- [ ] `$ARTIFACTS_DIR/plan.md` written with all 7 sections
+- [ ] No component files were created or edited in this step
+- [ ] The proposed API contains zero size:/color:/variant params
+
+## Phase 5: REPORT
+
+Reply with a 3–5 line summary: the component, its group, the parts/slots you
+chose, and the count of demo examples planned.

--- a/.archon/commands/loco-scaffold-component.md
+++ b/.archon/commands/loco-scaffold-component.md
@@ -1,0 +1,51 @@
+---
+description: Scaffold the 6 stub files for a new component using the new-component skill.
+argument-hint: (no arguments — reads $ARTIFACTS_DIR/naming.json and plan.md)
+---
+
+# Scaffold the New Component (stubs only)
+
+**Workflow ID**: $WORKFLOW_ID
+
+The `new-component` skill is preloaded. Use it to create the **minimal stub
+files** and register the component. Do NOT implement the real logic yet — that
+is the next step.
+
+## Phase 1: LOAD
+
+1. Read `$ARTIFACTS_DIR/naming.json` for the canonical names.
+2. Read `$ARTIFACTS_DIR/plan.md` for the file paths and the helpers.rb group
+   display string.
+
+## Phase 2: SCAFFOLD
+
+Follow the `new-component` skill end-to-end using those exact names:
+
+- Step 2 branch check will pass (the workflow already created the feature
+  branch). If it reports you are on `main`, STOP and report an error.
+- Create all stub files: the component class, the HAML template, the RSpec spec,
+  and the demo example view.
+- Register the component in `lib/loco_motion/helpers.rb` under the correct group.
+- Because `lib/loco_motion/helpers.rb` changed, restart the demo:
+  `touch docs/demo/tmp/restart.txt` (equivalent to `just demo-restart`, but
+  TTY-safe for this non-interactive run).
+
+## Phase 3: VALIDATE
+
+Run the project's validator (replace with the real values from naming.json):
+
+```bash
+python .claude/skills/shared-scripts/validate_component.py {component_name} {component_group}
+```
+
+All checks must pass. If a file is missing, create it from the skill's template
+and re-run the validator.
+
+### PHASE_3_CHECKPOINT
+- [ ] All 6 stub locations exist (4 new files + helpers.rb entry + the demo view)
+- [ ] `validate_component.py` exits 0
+- [ ] No real component logic added yet (stubs only)
+
+## Phase 4: REPORT
+
+List the files you created and confirm the validator passed.

--- a/.archon/config.yaml
+++ b/.archon/config.yaml
@@ -1,0 +1,10 @@
+# Project-scoped Archon config
+# Inherits defaults from ~/.archon/config.yaml.
+# Reference: https://archon.diy/reference/configuration/
+#
+# Examples:
+#   assistants:
+#     claude:
+#       model: sonnet
+#   docs:
+#     path: docs

--- a/.archon/workflows/loco-new-component.yaml
+++ b/.archon/workflows/loco-new-component.yaml
@@ -1,0 +1,152 @@
+# =============================================================================
+# loco-new-component
+# =============================================================================
+# Builds a complete new LocoMotion DaisyUI ViewComponent end-to-end and opens a
+# DRAFT pull request for human review.
+#
+# WHY worktree is OFF:
+#   The `loco` and `demo` containers bind-mount the PROJECT ROOT (`.:/home/...`)
+#   and we `docker compose exec` into the long-running containers. An Archon
+#   worktree is a *separate* directory the containers can't see, so tests run
+#   from a worktree would not reflect the worktree's changes. We therefore pin
+#   worktree OFF and create our own feature branch in the `prep` node.
+#
+#   Invoke WITHOUT --branch (a --branch flag will hard-error while pinned off):
+#     archon workflow run loco-new-component "stat in data_display"
+#
+# WHY `docker compose exec -T` instead of `just loco-test`:
+#   Every `just` test target uses `docker compose exec -it`. The `-t` allocates
+#   a TTY, which fails in Archon's non-interactive bash nodes ("the input device
+#   is not a TTY"). `-T` disables the pseudo-TTY and is the correct CI form. This
+#   is the one sanctioned deviation from the repo's "always use just" rule.
+# =============================================================================
+
+name: loco-new-component
+description: |
+  Build a brand-new LocoMotion DaisyUI ViewComponent from scratch, end-to-end:
+  component class + HAML template + RSpec spec + demo example + helpers.rb
+  registration + YARD docs + Playwright e2e + CHANGELOG, then open a DRAFT PR.
+  Use when the user wants to ADD a new Daisy component, e.g. "create a stat
+  component in data_display", "add a timeline component", "scaffold a kbd
+  component". Honors the repo's conventions: no size:/color: variant params,
+  define_part, one-component-per-PR, <=500 lines / <=10 files.
+  Does NOT modify existing components (that is loco-modify-component) and does
+  NOT fix bugs or implement from an issue plan (use the Archon default
+  workflows for those).
+
+provider: claude
+model: sonnet
+
+worktree:
+  enabled: false
+
+nodes:
+  # ── Extract the component name + group from the natural-language request ──
+  - id: parse-input
+    prompt: |
+      Extract the new-component request from this message:
+
+      $ARGUMENTS
+
+      Rules:
+      - component_name: SINGULAR snake_case (e.g. "text_input", "stat", "fab").
+      - component_group: exactly one of the enum values. Infer the best fit from
+        the request; if the user named a group, use it.
+      - component_title: Title Case, singular (e.g. "Text Input", "Stat").
+      - plural_name: snake_case PLURAL used for the demo view file name
+        (e.g. "text_inputs", "stats", "fabs", "categories").
+      - branch_name: literally "feat-add-" followed by component_name
+        (e.g. "feat-add-stat").
+    model: haiku
+    allowed_tools: []
+    output_format:
+      type: object
+      properties:
+        component_name: { type: string }
+        component_group:
+          type: string
+          enum: [actions, data_display, data_input, feedback, layout, navigation, mockup]
+        component_title: { type: string }
+        plural_name: { type: string }
+        branch_name: { type: string }
+      required: [component_name, component_group, component_title, plural_name, branch_name]
+
+  # ── Deterministic setup: feature branch, containers up, persist naming ──
+  - id: prep
+    depends_on: [parse-input]
+    timeout: 240000
+    bash: |
+      set -e
+      # Create (or switch to) the feature branch on the live checkout.
+      git checkout -b $parse-input.output.branch_name 2>/dev/null \
+        || git checkout $parse-input.output.branch_name
+      # Ensure the test containers are running (idempotent; no-op if already up).
+      docker compose up -d loco demo >/dev/null 2>&1 || true
+      # Persist the canonical naming for every downstream step to read.
+      printf '%s\n' $parse-input.output > "$ARTIFACTS_DIR/naming.json"
+      echo "branch: $parse-input.output.branch_name"
+      echo "naming written to $ARTIFACTS_DIR/naming.json"
+      cat "$ARTIFACTS_DIR/naming.json"
+
+  # ── Research the DaisyUI markup + closest existing component; write plan.md ─
+  - id: plan
+    command: loco-plan-component
+    depends_on: [prep]
+    context: fresh
+
+  # ── Scaffold the 6 stub files using the project's new-component skill ──
+  - id: scaffold
+    command: loco-scaffold-component
+    skills: [new-component]
+    depends_on: [plan]
+    context: fresh
+
+  # ── Implement the real component logic, template, spec, demo + YARD docs ──
+  - id: implement
+    command: loco-implement-component
+    skills: [modify-component, document-component]
+    depends_on: [scaffold]
+    context: fresh
+
+  # ── Run both RSpec suites; fix until green (deterministic gate) ──
+  - id: verify
+    depends_on: [implement]
+    idle_timeout: 600000
+    loop:
+      prompt: |
+        Make the new component's tests pass. Run BOTH suites:
+
+          docker compose exec -T loco bundle exec rspec spec
+          docker compose exec -T demo bundle exec rspec spec
+
+        Read the canonical naming from $ARTIFACTS_DIR/naming.json and the design
+        from $ARTIFACTS_DIR/plan.md. Fix ONLY the new component, its spec, its
+        demo example, or its helpers.rb entry — never unrelated code or specs.
+
+        Hard conventions (do not violate to make a test pass):
+        - No size:/color:/variant params — Daisy classes come via the css: kwarg.
+        - Use define_part; never define part(:component); no _css/_html for parts.
+        - The HAML template's root is `= part(:component) do`.
+
+        When BOTH suites pass with zero failures: <promise>GREEN</promise>.
+      until: GREEN
+      max_iterations: 6
+      fresh_context: false
+      until_bash: |
+        docker compose exec -T loco bundle exec rspec spec >/dev/null 2>&1 \
+          && docker compose exec -T demo bundle exec rspec spec >/dev/null 2>&1
+
+  # ── Write + run a Playwright e2e test for the demo page ──
+  - id: e2e
+    command: loco-e2e-component
+    skills: [playwright-tests]
+    depends_on: [verify]
+    context: fresh
+
+  # ── Update CHANGELOG and open a DRAFT PR using the repo template ──
+  - id: open-pr
+    command: loco-open-pr
+    skills: [create-pr]
+    depends_on: [implement, verify, e2e]
+    trigger_rule: all_done
+    context: fresh

--- a/.archon/workflows/loco-new-component.yaml
+++ b/.archon/workflows/loco-new-component.yaml
@@ -89,10 +89,17 @@ nodes:
       cat "$ARTIFACTS_DIR/naming.json"
 
   # ── Research the DaisyUI markup + closest existing component; write plan.md ─
+  # NOTE on `context: fresh` (here and below): it starts a fresh AI *session*
+  # (no memory of prior nodes — state flows through $ARTIFACTS_DIR artifacts).
+  # It does NOT create a git worktree; isolation is controlled solely by
+  # `worktree.enabled` above, which we pin off.
+  # Model: the plan's artifact steers every downstream node, so this single
+  # short node gets Fable (~2x Opus cost) — highest leverage per token.
   - id: plan
     command: loco-plan-component
     depends_on: [prep]
     context: fresh
+    model: claude-fable-5
 
   # ── Scaffold the 6 stub files using the project's new-component skill ──
   - id: scaffold
@@ -101,16 +108,28 @@ nodes:
     depends_on: [plan]
     context: fresh
 
-  # ── Implement the real component logic, template, spec, demo + YARD docs ──
+  # ── Implement the real component logic, template, spec, and demo ──
+  # Model: the bulk of the code generation — Opus-worthy. Fable here would
+  # double the cost of the longest node for little gain over a strong plan.
   - id: implement
     command: loco-implement-component
-    skills: [modify-component, document-component]
+    skills: [modify-component]
     depends_on: [scaffold]
+    context: fresh
+    model: opus
+
+  # ── Add the full YARD documentation as its own focused step ──
+  - id: document
+    command: loco-document-component
+    skills: [document-component]
+    depends_on: [implement]
     context: fresh
 
   # ── Run both RSpec suites; fix until green (deterministic gate) ──
+  # (Loop nodes ignore per-node model overrides — this runs at the workflow
+  # default, sonnet, which suits the mechanical run-fix cycle.)
   - id: verify
-    depends_on: [implement]
+    depends_on: [document]
     idle_timeout: 600000
     loop:
       prompt: |
@@ -147,6 +166,6 @@ nodes:
   - id: open-pr
     command: loco-open-pr
     skills: [create-pr]
-    depends_on: [implement, verify, e2e]
+    depends_on: [implement, document, verify, e2e]
     trigger_rule: all_done
     context: fresh

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ builds/
 .DS_Store
 spec/internal/
 NEXT_SESSION.md
+
+# Archon (archon.diy) — vendored skill + runtime artifacts (not project source).
+# Workflow/command/script definitions under .archon/ ARE committed.
+.claude/skills/archon/
+.archon/state/
+.archon/.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - chore(Release): Replace the `make` targets in `bin/release` with their `just` equivalents to match the project's
   task runner.
 - chore(Repo): Fix the `.gitignore` `.DS_Store` pattern and remove a stray `.DS_Store` from `lib/loco_motion/patches`.
+- chore(Archon): Add Archon (archon.diy) workflow tooling under `.archon/` — the `loco-new-component`
+  workflow plus five command files that build a DaisyUI component end-to-end (plan, scaffold, implement,
+  verify, e2e, draft PR) by reusing the existing Claude skills. Also gitignore the vendored
+  `.claude/skills/archon/` skill and Archon runtime artifacts (`.archon/state/`, `.archon/.env`).
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   task runner.
 - chore(Repo): Fix the `.gitignore` `.DS_Store` pattern and remove a stray `.DS_Store` from `lib/loco_motion/patches`.
 - chore(Archon): Add Archon (archon.diy) workflow tooling under `.archon/` — the `loco-new-component`
-  workflow plus five command files that build a DaisyUI component end-to-end (plan, scaffold, implement,
-  verify, e2e, draft PR) by reusing the existing Claude skills. Also gitignore the vendored
+  workflow plus six command files that build a DaisyUI component end-to-end (plan, scaffold, implement,
+  document, verify, e2e, draft PR) by reusing the existing Claude skills. Also gitignore the vendored
   `.claude/skills/archon/` skill and Archon runtime artifacts (`.archon/state/`, `.archon/.env`).
 
 ### Documentation


### PR DESCRIPTION
## Context

I installed Archon (archon.diy) to run autonomous, multi-step coding workflows in isolated runs. Archon ships ~20 generic workflows; this PR adds the first LocoMotion-specific one so Archon understands our component conventions — the 6-file component anatomy, the no <code>size:</code>/<code>color:</code> variant rule, <code>define_part</code>, <code>helpers.rb</code> registration, YARD <code>@loco_example</code>, and the one-component-per-PR size limits — that the generic workflows cannot know.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [x] Other (please describe): Internal developer tooling — Archon workflow automation

## Description

- Add <code>.archon/workflows/loco-new-component.yaml</code>: an end-to-end workflow that builds a brand-new DaisyUI component (parse → plan → scaffold → implement → document → verify → e2e → draft PR), reusing the existing Claude skills via Archon's <code>skills:</code> node injection.
- Add six command files under <code>.archon/commands/</code> that drive each phase: <code>loco-plan-component</code>, <code>loco-scaffold-component</code>, <code>loco-implement-component</code>, <code>loco-document-component</code>, <code>loco-e2e-component</code>, and <code>loco-open-pr</code>.
- Add <code>.archon/config.yaml</code> (project-scoped Archon config stub).
- Update <code>.gitignore</code> to ignore the vendored <code>.claude/skills/archon/</code> skill and Archon runtime artifacts (<code>.archon/state/</code>, <code>.archon/.env</code>) while keeping the workflow definitions tracked.
- Log the change under Tooling &amp; Standards in <code>CHANGELOG.md</code>.

Three deliberate design choices are documented in the workflow file: it pins worktree isolation off and calls <code>docker compose exec -T</code> directly (not <code>just</code>, whose <code>-it</code> flags need a TTY) because the <code>loco</code>/<code>demo</code> containers bind-mount the project root, so an isolated worktree would be invisible to the running test containers. Models are tiered by leverage: the <code>plan</code> node runs Fable (highest-leverage artifact, small token volume), <code>implement</code> runs Opus, and glue nodes stay on sonnet/haiku.

Notes for review: this is tooling/config only — no Ruby, HAML, or JS changed, so the RSpec/Playwright suites are unaffected. The workflow and all six command files were validated with <code>archon validate</code> (all pass). The diff is ~611 lines across 10 files (over the 500-line guideline) because the command files are prose-heavy; it is a single logical concern, and splitting the workflow from its own command files would leave it non-functional.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)
