### PR TITLE
docs(CLAUDE): Exempt PR descriptions from the 80-char wrap rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,9 @@ daisy_button(color: :primary, size: :lg)
   keeps each entry readable. Indent continuation lines to align with the text
   after the list marker (2 spaces under a top-level `- `, 4 under a nested
   `  - `).
+- Exception: pull request descriptions are exempt from line wrapping — GitHub
+  renders them as flowing prose, so the 80-character limit does not apply. Write
+  natural paragraphs and let them wrap on render.
 - Never split an inline code span (`` `...` ``), a Markdown link
   (`[text](url)`), or a `<code>` tag across lines. A line may exceed its limit
   only when one such unbreakable token is itself too long; prose must always


### PR DESCRIPTION
## Context

While reviewing PR #130 we noticed its description had been hard-wrapped at 80 characters, which is unnecessary: GitHub renders PR descriptions as flowing prose, so the 80-character wrap that applies to source and Markdown files in the repo does not need to apply to PR bodies.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

Adds an exception bullet under the <code>Markdown / Documentation</code> section of <code>CLAUDE.md</code>, alongside the existing <code>CHANGELOG.md</code> 110-character exception, stating that pull request descriptions are exempt from line wrapping and should be written as natural paragraphs that wrap on render.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [ ] I have updated the CHANGELOG.md file (if applicable)
