### PR TITLE
fix(Algolia): Stop exposing write-capable API key to the browser

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -87,6 +87,7 @@ jobs:
         SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE || 'ci_placeholder_not_used_in_production' }}
         ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
         ALGOLIA_APPLICATION_ID: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+        ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
         UNSPLASH_ACCESS_KEY: ${{ secrets.UNSPLASH_ACCESS_KEY }}
         UNSPLASH_SECRET_KEY: ${{ secrets.UNSPLASH_SECRET_KEY }}
         # Variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   page, and remove the stale issue #49 flash-of-content comment
 - fix(demo): Restore plain-Ruby guard in `docs/demo/bin/bundle` — `.present?` (ActiveSupport) is not
   available when the binstub runs, causing a `NoMethodError` on Heroku during `bundle install`
+- fix(demo): Stop exposing the write-capable Algolia API key to the browser — `algolia_credentials_tag` now
+  injects a new search-only `ALGOLIA_SEARCH_API_KEY`, while `ALGOLIA_API_KEY` (write access) stays
+  server-side for the indexing rake tasks and Heroku release phase
+- docs(Algolia): Document the write/search API key split in `docs/dev_guides/ALGOLIA.md` and pass the new
+  search key through the Playwright CI workflow
 
 ### Changed
 

--- a/docs/demo/app/helpers/algolia_helper.rb
+++ b/docs/demo/app/helpers/algolia_helper.rb
@@ -3,6 +3,10 @@
 # Helper for Algolia search integration
 module AlgoliaHelper
   # Generate JavaScript tag that injects Algolia credentials as window variables
+  #
+  # This tag is rendered on every public page, so it must only ever expose the
+  # search-only key (ALGOLIA_SEARCH_API_KEY). The write-capable ALGOLIA_API_KEY
+  # is reserved for server-side indexing and must never be rendered here.
   def algolia_credentials_tag
     # Use raw JavaScript content instead of javascript_tag helper
     env = ENV["ALGOLIA_ENV"] || Rails.env
@@ -10,7 +14,7 @@ module AlgoliaHelper
       <script type="text/javascript">
         window.algoliaCredentials = {
           appId: '#{ENV.fetch('ALGOLIA_APPLICATION_ID', nil)}',
-          apiKey: '#{ENV.fetch('ALGOLIA_API_KEY', nil)}',
+          apiKey: '#{ENV.fetch('ALGOLIA_SEARCH_API_KEY', nil)}',
           indexName: "loco_motion_#{env}_components_#{LocoMotion::VERSION}"
         };
       </script>

--- a/docs/demo/config/initializers/algolia.rb
+++ b/docs/demo/config/initializers/algolia.rb
@@ -3,7 +3,9 @@
 # This initializer configures the Algolia search integration for LocoMotion.
 # You need to set the following environment variables:
 # - ALGOLIA_APPLICATION_ID: Your Algolia application ID
-# - ALGOLIA_API_KEY: Your Algolia API key (write access for indexing, read-only for search)
+# - ALGOLIA_API_KEY: Your write-capable Algolia API key, used server-side only
+#   for indexing (rake tasks / release phase). Never expose it to the browser;
+#   the frontend search uses the separate ALGOLIA_SEARCH_API_KEY instead.
 
 if defined?(Rails) && defined?(AlgoliaSearch)
   # Only attempt to configure if we have credentials

--- a/docs/dev_guides/ALGOLIA.md
+++ b/docs/dev_guides/ALGOLIA.md
@@ -19,15 +19,23 @@ demo application.
 
 ## Environment Variables
 
-To upload data to Algolia, you need to set the following environment variables
-in the demo application's `.env.local` file:
+The integration uses two separate API keys with different permission levels:
 
 - `ALGOLIA_APPLICATION_ID`: Your Algolia application ID
-- `ALGOLIA_API_KEY`: Your Algolia API key with write access
+- `ALGOLIA_API_KEY`: A **write-capable** key (`addObject`, `deleteObject`,
+  etc.) used only by the server-side indexing rake tasks and the Heroku
+  release phase. This key must **never** be exposed to the browser.
+- `ALGOLIA_SEARCH_API_KEY`: A **search-only** key injected into every demo
+  page (via `algolia_credentials_tag`) to power the frontend search UI. Create
+  it in the Algolia dashboard with only the `search` ACL.
 - `DEBUG`: Set to 'true' to enable verbose debug output (optional)
 
-If these credentials are not provided, the indexing operation will still
-generate a JSON file locally, but data won't be uploaded to Algolia.
+Set all of these in the demo application's `.env.local` file for local
+development, and in the Heroku config vars for deployed environments.
+
+If the write credentials are not provided, the indexing operation will still
+generate a JSON file locally, but data won't be uploaded to Algolia. If the
+search key is not provided, the frontend search box won't return results.
 
 
 ## Available Commands
@@ -98,7 +106,8 @@ The following environment variables control the Algolia integration:
 | Variable | Description |
 | -------- | ----------- |
 | `ALGOLIA_APPLICATION_ID` | Your Algolia application ID |
-| `ALGOLIA_API_KEY` | Your Algolia API key with write permissions |
+| `ALGOLIA_API_KEY` | Write-capable API key, server-side indexing only — never sent to the browser |
+| `ALGOLIA_SEARCH_API_KEY` | Search-only API key exposed to the browser for the frontend search UI |
 | `ALGOLIA_ENV` | Environment name used in the index name (e.g., `production`, `staging`) |
 
 ### algolia-clear


### PR DESCRIPTION
## Context

The demo app's <code>algolia_credentials_tag</code> helper injects Algolia credentials into a script tag on every public page so the frontend search UI can query the index. It was injecting <code>ALGOLIA_API_KEY</code> — the same key used by the server-side indexing rake tasks, which carries admin-level ACLs (addObject, deleteObject, deleteIndex, editSettings). That write-capable key was therefore publicly visible on the deployed demo site, allowing anyone to modify or delete the search index.

This PR splits the credentials: the browser now receives a dedicated search-only key, and the write key remains server-side only.

## Related Issues

None — found during a security review of the demo app.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- <code>docs/demo/app/helpers/algolia_helper.rb</code>: <code>algolia_credentials_tag</code> now injects the new <code>ALGOLIA_SEARCH_API_KEY</code> environment variable instead of <code>ALGOLIA_API_KEY</code>, with a comment documenting that only a search-only key may ever be rendered client-side.
- <code>docs/demo/config/initializers/algolia.rb</code>: Clarified that <code>ALGOLIA_API_KEY</code> is the server-side write key for indexing only.
- <code>docs/dev_guides/ALGOLIA.md</code>: Documented the write/search key split in both environment-variable sections.
- <code>.github/workflows/playwright.yml</code>: Passes <code>ALGOLIA_SEARCH_API_KEY</code> to the Rails server step so frontend search works in CI once the secret is configured (no e2e tests currently exercise search, so CI passes either way).

**Deployment steps required after merge (cannot be done in code):**

1. Create a new search-only key (search ACL only) in the Algolia dashboard.
2. Set <code>ALGOLIA_SEARCH_API_KEY</code> on the Heroku staging/production config vars and in local <code>.env.local</code> files.
3. **Rotate the existing <code>ALGOLIA_API_KEY</code>** — it has been publicly exposed on the staging site and must be considered compromised. Update the rotated value on Heroku and in the GitHub Actions secret.

Until step 2 is done, the demo's search box will return no results in deployed environments — that is the intended fail-safe direction.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)