### PR TITLE
fix(Release): Always run version update and fix checklist gsub patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   workflow plus six command files that build a DaisyUI component end-to-end (plan, scaffold, implement,
   document, verify, e2e, draft PR) by reusing the existing Claude skills. Also gitignore the vendored
   `.claude/skills/archon/` skill and Archon runtime artifacts (`.archon/state/`, `.archon/.env`).
+- fix(Release): In `bin/release`, always run the version-update step even when a version is passed as a
+  CLI argument (previously `bin/release 0.6.0` skipped `just version-set` and `just loco-version-lock`,
+  releasing stale artifacts), and fix the checklist auto-check `gsub!` patterns that used regex escapes
+  inside plain strings and therefore never matched any checkbox lines.
 
 ### Documentation
 

--- a/bin/release
+++ b/bin/release
@@ -506,33 +506,33 @@ def update_checklist(version, dry_run: false)
   content = File.read(checklist_path)
 
   # Mark pre-release preparation as completed
-  content.gsub!('- \[ \] All tests are passing locally', '- [x] All tests are passing locally')
-  content.gsub!('- \[ \] All documentation is up to date', '- [x] All documentation is up to date')
-  content.gsub!('- \[ \] All changes are committed and pushed', '- [x] All changes are committed and pushed')
-  content.gsub!('- \[ \] Review any breaking changes', '- [x] Review any breaking changes')
+  content.gsub!('- [ ] All tests are passing locally', '- [x] All tests are passing locally')
+  content.gsub!('- [ ] All documentation is up to date', '- [x] All documentation is up to date')
+  content.gsub!('- [ ] All changes are committed and pushed', '- [x] All changes are committed and pushed')
+  content.gsub!('- [ ] Review any breaking changes', '- [x] Review any breaking changes')
 
   # Mark version update steps as completed
   content.gsub!(/- \[ \] Update version:.*$/, '- [x] Update version: `just version-set ' + version + '`')
-  content.gsub!('- \[ \] Review version changes', '- [x] Review version changes')
-  content.gsub!('- \[ \] Update loco container', '- [x] Update loco container')
+  content.gsub!('- [ ] Review version changes', '- [x] Review version changes')
+  content.gsub!('- [ ] Update loco container', '- [x] Update loco container')
 
   # Mark changelog as completed
-  content.gsub!('- \[ \] Add new version section', '- [x] Add new version section')
-  content.gsub!('- \[ \] Include all relevant changes', '- [x] Include all relevant changes')
-  content.gsub!('- \[ \] Use proper formatting', '- [x] Use proper formatting')
+  content.gsub!('- [ ] Add new version section', '- [x] Add new version section')
+  content.gsub!('- [ ] Include all relevant changes', '- [x] Include all relevant changes')
+  content.gsub!('- [ ] Use proper formatting', '- [x] Use proper formatting')
 
   # Mark building steps as completed
-  content.gsub!('- \[ \] Build Ruby gem', '- [x] Build Ruby gem')
-  content.gsub!('- \[ \] Verify gem build', '- [x] Verify gem build')
-  content.gsub!('- \[ \] Build NPM package', '- [x] Build NPM package')
-  content.gsub!('- \[ \] Verify NPM package', '- [x] Verify NPM package')
+  content.gsub!('- [ ] Build Ruby gem', '- [x] Build Ruby gem')
+  content.gsub!('- [ ] Verify gem build', '- [x] Verify gem build')
+  content.gsub!('- [ ] Build NPM package', '- [x] Build NPM package')
+  content.gsub!('- [ ] Verify NPM package', '- [x] Verify NPM package')
 
   # Mark PR steps as completed
   content.gsub!(/- \[ \] Commit all changes:.*$/, '- [x] Commit all changes: `git commit -am "Release version ' + version + '"`')
-  content.gsub!('- \[ \] Create pull request', '- [x] Create pull request')
-  content.gsub!('- \[ \] Get pull request reviewed', '- [x] Get pull request reviewed')
-  content.gsub!('- \[ \] Merge pull request', '- [x] Merge pull request')
-  content.gsub!('- \[ \] Pull latest main locally', '- [x] Pull latest main locally')
+  content.gsub!('- [ ] Create pull request', '- [x] Create pull request')
+  content.gsub!('- [ ] Get pull request reviewed', '- [x] Get pull request reviewed')
+  content.gsub!('- [ ] Merge pull request', '- [x] Merge pull request')
+  content.gsub!('- [ ] Pull latest main locally', '- [x] Pull latest main locally')
 
   # Mark tag as completed
   content.gsub!(/- \[ \] Create and push version tag:.*$/, '- [x] Create and push version tag: `git tag v' + version + ' && git push origin v' + version + '`')
@@ -580,7 +580,6 @@ def main
 
   # Parse arguments
   dry_run = ARGV.include?('--dry-run')
-  version_arg = ARGV.find { |arg| !arg.start_with?('--') && !arg.start_with?('-') }
 
   # Show help if requested
   if ARGV.include?('--help') || ARGV.include?('-h')
@@ -626,7 +625,7 @@ def main
   begin
     check_prerequisites(dry_run: dry_run)
 
-    version = version_arg || update_version(dry_run: dry_run)
+    version = update_version(dry_run: dry_run)
     update_changelog(version, dry_run: dry_run)
     generate_llms_docs(version, dry_run: dry_run)
     build_packages(dry_run: dry_run)


### PR DESCRIPTION
## Context

The interactive release wizard <code>bin/release</code> had two bugs that surfaced during the v0.5.2 release: passing a version on the command line silently skipped the entire version-update step, and the release-checklist auto-update never checked any boxes (see <code>docs/checklists/release-checklist-v0.5.2.md</code>, which was left fully unchecked).

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- In <code>main()</code>, <code>version = version_arg || update_version(dry_run: dry_run)</code> meant that running <code>bin/release 0.6.0</code> never called <code>update_version</code> at all — <code>just version-set</code> and <code>just loco-version-lock</code> never ran, the version files stayed at the prior version, and <code>build_packages</code> happily reused the stale prior-version artifacts while the CHANGELOG, tag, and GitHub release all used the new version. Since <code>update_version</code> already reads the version argument from <code>ARGV</code> internally, <code>main()</code> now always calls it, and the unused <code>version_arg</code> parsing in <code>main()</code> is removed.
- In <code>update_checklist()</code>, most <code>gsub!</code> calls passed single-quoted strings containing regex escapes (e.g. <code>'- \[ \] All tests are passing locally'</code>). String patterns match literally — backslashes included — so these never matched the actual checklist lines and no checkboxes were ever auto-checked. They are now plain literal strings without escapes; the patterns that need line-tail replacement were already proper Regexp literals and are unchanged.
- The corrupted v0.5.2 checklist footer (<code>**Release Date**: 0.5.2</code>) turned out to come from the checklist *generation* recipe in the <code>justfile</code> (its <code>sed</code> replaces every <code>___________</code> placeholder with the version), not from this script — the footer <code>gsub!</code> calls here are correct Regexp literals and will now also repair such footers when the script runs.

Verified with <code>ruby bin/release 0.6.0 --dry-run</code>: before the fix, STEP 1 (Update Version) never appeared and STEP 3 reported the stale 0.5.2 packages as already built; after the fix, STEP 1 runs and reports "Would update version from 0.5.2 to 0.6.0". The checklist substitutions were verified by replaying the fixed <code>gsub!</code> block against the v0.5.2 checklist: 0 → 22 boxes checked and the footer correctly rewritten.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)
