### PR TITLE
fix(Release): Only stamp the version into the Release Version line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   CLI argument (previously `bin/release 0.6.0` skipped `just version-set` and `just loco-version-lock`,
   releasing stale artifacts), and fix the checklist auto-check `gsub!` patterns that used regex escapes
   inside plain strings and therefore never matched any checkbox lines.
+- fix(Release): Anchor the `create-checklist` placeholder `sed` to the `**Release Version**` line so the
+  version is no longer stamped into the `**Release Date**` and `**Released By**` footer lines, and set those
+  template placeholders to `TBD` (the v0.5.2 checklist ended up with `**Release Date**: 0.5.2`).
 
 ### Documentation
 

--- a/docs/templates/release_checklist.md
+++ b/docs/templates/release_checklist.md
@@ -104,5 +104,5 @@ Use this checklist to ensure all steps are completed for a LocoMotion release.
 ---
 
 **Release Version**: ___________
-**Release Date**: ___________
-**Released By**: ___________
+**Release Date**: TBD
+**Released By**: TBD

--- a/justfile
+++ b/justfile
@@ -209,7 +209,7 @@ create-checklist version:
     @sed -i '' 's/Release Checklist Template/Release Checklist for v{{version}}/g' docs/checklists/release-checklist-v{{version}}.md
     @sed -i '' 's/x\.y\.z/{{version}}/g' docs/checklists/release-checklist-v{{version}}.md
     @sed -i '' 's/\[VERSION\]/{{version}}/g' docs/checklists/release-checklist-v{{version}}.md
-    @sed -i '' 's/___________/{{version}}/g' docs/checklists/release-checklist-v{{version}}.md
+    @sed -i '' '/\*\*Release Version\*\*/s/___________/{{version}}/' docs/checklists/release-checklist-v{{version}}.md
     @echo "✓ Created release checklist: docs/checklists/release-checklist-v{{version}}.md"
 
 # Bump the version using the update_version script


### PR DESCRIPTION
## Context

The <code>create-checklist</code> recipe in the <code>justfile</code> stamps the version into the generated checklist with a blanket <code>sed 's/___________/{{version}}/g'</code>. The template footer has three placeholder lines (<code>**Release Version**</code>, <code>**Release Date**</code>, and <code>**Released By**</code>), so all three got the version number — which is why <code>docs/checklists/release-checklist-v0.5.2.md</code> ended up with <code>**Release Date**: 0.5.2</code> and <code>**Released By**: 0.5.2</code>.

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Anchor the placeholder <code>sed</code> in the <code>create-checklist</code> recipe to the <code>**Release Version**</code> line so only that line receives the version.
- Set the <code>**Release Date**</code> and <code>**Released By**</code> placeholders in <code>docs/templates/release_checklist.md</code> to <code>TBD</code>, matching the v0.6.0 checklist — they are filled in by hand at release time.
- Verified by running <code>just create-checklist</code> with a test version and confirming only the Release Version footer line is stamped.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
