### PR TITLE
fix(Release): Commit llms.txt from docs/demo/public in release wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - fix(Release): Read interactive prompts from `$stdin` in `bin/release` and
   `bin/update_demo_after_release` — bare `gets` reads from `ARGF`, so with a version argument the first
   prompt crashed trying to open a file named after the version (e.g. `0.6.0`).
+- fix(Release): Point the `bin/release` llms.txt commit step at the actual generated files
+  (`docs/demo/public/llms*.txt`) instead of the repo-root `llms.txt`/`llms-full.txt` — the v0.6.0 release
+  failed with `fatal: pathspec 'llms.txt' did not match any files` — and include `docs/demo/Gemfile.lock`,
+  which `just llm` can dirty by refreshing the demo container's bundle stamp. Also fix the `LLM*.txt`
+  filename casing in `RELEASING.md` (the generated files are lowercase `llms*.txt`).
 
 ### Documentation
 

--- a/bin/release
+++ b/bin/release
@@ -218,7 +218,10 @@ def generate_llms_docs(version, dry_run: false)
 
     response = prompt_yes_no("Commit llms.txt changes?", default: 'y')
     if response == 'y'
-      execute_command("Committing llms.txt", "git add llms.txt llms-full.txt && git commit -m 'docs: Update llms.txt for release v#{version}'")
+      # `just llm` writes the files into docs/demo/public/ (llms.txt,
+      # llms-full.txt, and versioned copies). It also boots the demo
+      # container, which can refresh docs/demo/Gemfile.lock, so include it.
+      execute_command("Committing llms.txt", "git add docs/demo/public/llms*.txt docs/demo/Gemfile.lock && git commit -m 'docs: Update llms.txt for release v#{version}'")
     end
   else
     puts "INFO: Skipping llms.txt generation (you can run it later with 'just llm')"

--- a/docs/dev_guides/RELEASING.md
+++ b/docs/dev_guides/RELEASING.md
@@ -259,8 +259,9 @@ LLM-friendly documentation files:
    ```
 
    This will:
-   - Generate comprehensive LLM.txt files with all component documentation
-   - Create both versioned (`LLM-vX.X.X.txt`) and versionless (`LLM.txt`) copies
+   - Generate comprehensive llms.txt files with all component documentation
+   - Create both versioned (`llms-vX.X.X.txt` / `llms-full-vX.X.X.txt`) and
+     versionless (`llms.txt` / `llms-full.txt`) copies
    - Include usage patterns, component examples, and helper method documentation
    - Place files in the demo public directory for HTTP access
 
@@ -268,7 +269,7 @@ LLM-friendly documentation files:
 
    ```bash
    # Check that files were generated
-   ls -la docs/demo/public/LLM*.txt
+   ls -la docs/demo/public/llms*.txt
 
    # Verify content quality
    docker compose exec -it demo bundle exec rake algolia:llm
@@ -277,10 +278,14 @@ LLM-friendly documentation files:
 3. **Commit the generated files**:
 
    ```bash
-   git add docs/demo/public/LLM*.txt
+   git add docs/demo/public/llms*.txt docs/demo/Gemfile.lock
    git commit -m "Generate LLM documentation for version X.X.X"
    git push
    ```
+
+   Note: running `just llm` boots the demo container, which can refresh
+   `docs/demo/Gemfile.lock` (the demo bundle stamp). If it is dirty at this
+   point, include it in the commit as shown above.
 
 The LLM documentation is used by AI assistants to provide better code
 generation and support for LocoMotion components.


### PR DESCRIPTION
## Context

During the v0.6.0 release, the wizard's "Generate LLM Documentation" step failed with `fatal: pathspec 'llms.txt' did not match any files` and the generated files had to be committed manually. The <code>generate_llms_docs</code> function in <code>bin/release</code> ran `git add llms.txt llms-full.txt` against the repo root, but `just llm` actually writes the files to <code>docs/demo/public/</code> (versionless <code>llms.txt</code> / <code>llms-full.txt</code> plus versioned <code>llms-vX.X.X.txt</code> / <code>llms-full-vX.X.X.txt</code> copies). The release guide also referenced the files with the wrong casing (`LLM*.txt`).

## Related Issues

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- <code>bin/release</code>: the llms.txt commit step now stages <code>docs/demo/public/llms*.txt</code>, which picks up the versionless files and the new versioned copies. It also stages <code>docs/demo/Gemfile.lock</code>, because `just llm` boots the demo container, which can refresh the bundle stamp and leave the lockfile dirty mid-release (staging it is a no-op when it is clean).
- <code>docs/dev_guides/RELEASING.md</code>: corrected the `LLM*.txt` references to the actual lowercase `llms*.txt` filenames in the "LLM Documentation Generation" step, listed the real versioned filenames, and documented the possible <code>docs/demo/Gemfile.lock</code> change in the commit step.
- <code>CHANGELOG.md</code>: added an entry under the Unreleased section.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

https://claude.ai/code/session_017yH1HVecyP4bTGpirKi4A3

---
_Generated by [Claude Code](https://claude.ai/code/session_017yH1HVecyP4bTGpirKi4A3)_