### PR TITLE
feat(Release): Add publish auth pre-checks and Retry/Skip/Abort loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ project "released" until that point in time.
 We plan to use patch versions only for bug fixes, and for now, all **minor releases** should be considered
 **breaking**!
 
+## [Unreleased]
+
+### General Changes
+
+- Added publishing auth pre-checks and a Retry / Skip / Abort loop to `bin/release` — before each publish
+  the wizard now verifies credentials (`npm whoami` for NPM, a readable `~/.gem/credentials` for RubyGems)
+  and, when a pre-check or publish fails, prints the fix (`npm login` / `gem signin`) and re-prompts so you
+  can fix credentials in another terminal and retry without restarting the wizard. The same checks run as
+  early non-fatal warnings in the prerequisites step, and the dry-run output describes the new behavior.
+
 ## [0.6.0] - 2026-06-12
 
 ### Tooling & Standards

--- a/bin/release
+++ b/bin/release
@@ -30,6 +30,43 @@ def prompt_yes_no(message, default: 'n')
   end
 end
 
+def prompt_retry_skip_abort(message)
+  loop do
+    print "#{message} (r)etry / (s)kip / (a)bort: "
+    response = $stdin.gets.strip.downcase
+    return 'retry' if %w[r retry].include?(response)
+    return 'skip' if %w[s skip].include?(response)
+    return 'abort' if %w[a abort].include?(response)
+    puts "WARNING: Please enter 'r', 's', or 'a'."
+  end
+end
+
+def check_npm_auth
+  output = `npm whoami 2>&1`.strip
+  if $?.success?
+    puts "SUCCESS: NPM authenticated as '#{output}'"
+    true
+  else
+    puts "WARNING: NPM auth pre-check failed (npm whoami):"
+    output.each_line { |line| puts "   #{line.rstrip}" }
+    puts "   Your npm login is missing or expired. Run 'npm login' in another terminal."
+    puts "   Note: 'npm publish' reports a misleading E404 for scoped packages when auth fails."
+    false
+  end
+end
+
+def check_gem_auth
+  credentials_path = File.expand_path('~/.gem/credentials')
+  if File.readable?(credentials_path)
+    puts "SUCCESS: RubyGems credentials found at #{credentials_path}"
+    true
+  else
+    puts "WARNING: RubyGems credentials not found (or not readable) at #{credentials_path}"
+    puts "   Run 'gem signin' in another terminal to authenticate."
+    false
+  end
+end
+
 def execute_command(description, command, exit_on_failure: true)
   puts "\nEXEC: #{description}"
   puts "   Running: #{command}"
@@ -80,6 +117,14 @@ def check_prerequisites(dry_run: false)
   else
     puts "SUCCESS: No uncommitted changes"
   end
+
+  # Warn early about missing publishing credentials so they can be fixed
+  # before the release work starts. Non-fatal: publishing (step 6) re-checks
+  # and offers a retry loop.
+  puts "\nCHECK: Checking publishing credentials (warnings only)..."
+  check_gem_auth
+  check_npm_auth
+  puts
 
   # Check if tests pass (skip in dry run as it runs commands)
   if dry_run
@@ -393,43 +438,91 @@ def tag_release(version, dry_run: false)
   execute_command("Pushing tag to origin", "git push origin v#{version}")
 end
 
+def publish_with_retries(name, command, auth_check:, fix_hint:)
+  loop do
+    failure = nil
+
+    if send(auth_check)
+      if execute_command("Publishing #{name}", command, exit_on_failure: false)
+        return true
+      end
+      puts "   #{fix_hint}"
+      failure = "publish failed"
+    else
+      failure = "auth pre-check failed"
+    end
+
+    puts
+    case prompt_retry_skip_abort("#{name}: #{failure}. Fix credentials in another terminal, then:")
+    when 'retry'
+      next
+    when 'skip'
+      puts "INFO: Skipping #{name} publishing."
+      return false
+    when 'abort'
+      puts "WARNING: Aborting release. Resolve publishing issues and re-run bin/release."
+      exit 1
+    end
+  end
+end
+
 def publish_packages(dry_run: false)
   puts "\nSTEP 6: Publish Packages"
   puts "=" * 50
 
   if dry_run
     puts "DRY RUN: Skipping package publishing"
+    puts "   Would run an auth pre-check before each publish:"
+    puts "   - RubyGems: verify ~/.gem/credentials exists ('gem signin' to fix)"
+    puts "   - NPM: run 'npm whoami' ('npm login' to fix)"
     puts "   Would publish:"
     puts "   - Ruby gem to RubyGems.org"
     puts "   - NPM package to npmjs.com"
+    puts "   On a failed pre-check or publish, would prompt Retry / Skip / Abort"
+    puts "   so credentials can be fixed without restarting the wizard."
     return
   end
 
   puts "   This step requires your credentials for both RubyGems and NPM."
-  puts "   The script will run the publishing commands, but you may need to"
-  puts "   authenticate when prompted."
+  puts "   Each publish runs an auth pre-check first. If a pre-check or a"
+  puts "   publish fails, you can fix your credentials in another terminal"
+  puts "   and retry without restarting the wizard."
   puts
 
   # Publish Ruby gem
+  gem_published = false
   puts "INFO: Publishing Ruby Gem to RubyGems.org..."
   response = prompt_yes_no("Continue with gem publishing?", default: 'y')
   if response == 'y'
-    execute_command("Publishing Ruby gem", "just gem-publish", exit_on_failure: false)
-    puts "   Verify at: https://rubygems.org/gems/loco_motion-rails"
+    gem_published = publish_with_retries(
+      "Ruby gem", "just gem-publish",
+      auth_check: :check_gem_auth,
+      fix_hint: "If this is an auth problem, run 'gem signin' in another terminal."
+    )
+    puts "   Verify at: https://rubygems.org/gems/loco_motion-rails" if gem_published
   end
 
   # Publish NPM package
+  npm_published = false
   puts "\nINFO: Publishing NPM package to npmjs.com..."
   response = prompt_yes_no("Continue with NPM publishing?", default: 'y')
   if response == 'y'
-    execute_command("Publishing NPM package", "just npm-publish", exit_on_failure: false)
-    puts "   Verify at: https://www.npmjs.com/package/@profoundry-us/loco_motion"
+    npm_published = publish_with_retries(
+      "NPM package", "just npm-publish",
+      auth_check: :check_npm_auth,
+      fix_hint: "An E404 here usually means expired auth ('npm whoami' to check, 'npm login' to fix)."
+    )
+    puts "   Verify at: https://www.npmjs.com/package/@profoundry-us/loco_motion" if npm_published
   end
 
-  response = prompt_yes_no("Were both packages published successfully?", default: 'n')
-  unless response == 'y'
-    puts "WARNING: Please resolve any publishing issues before continuing."
-    exit 1
+  unless gem_published && npm_published
+    skipped = []
+    skipped << "Ruby gem ('just gem-publish')" unless gem_published
+    skipped << "NPM package ('just npm-publish')" unless npm_published
+    puts "\nWARNING: Not published: #{skipped.join(', ')}."
+    puts "   You can publish manually later with the commands above."
+    response = prompt_yes_no("Continue with the rest of the release anyway?", default: 'n')
+    exit 1 unless response == 'y'
   end
 end
 


### PR DESCRIPTION
## Context

During the v0.6.0 release, <code>just npm-publish</code> failed with a misleading E404 — npm returns 404 on PUT for scoped packages when auth fails, and <code>npm whoami</code> revealed the real problem (401, expired token). The wizard never checked credentials before publishing, and the only path forward after the failure was the "Were both packages published successfully?" gate, which exits the wizard entirely, forcing a full restart after fixing the token.

## Related Issues

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Added auth pre-checks in <code>bin/release</code> that run before each publish: <code>npm whoami</code> for NPM (failure prints the npm output, tells the user to run <code>npm login</code> in another terminal, and notes the misleading E404 behavior) and a readable <code>~/.gem/credentials</code> for RubyGems (failure points to <code>gem signin</code>; there is no perfect whoami equivalent for RubyGems).
- Added <code>publish_with_retries</code>: when a pre-check or a publish fails, the wizard no longer exits — it prints the fix instruction and loops with a Retry / Skip / Abort prompt so credentials can be fixed in another terminal and the same step retried without restarting the whole wizard.
- The unconditional "Were both packages published successfully?" exit gate is replaced by a summary that only gates (default n) when a package was actually skipped, listing the manual <code>just gem-publish</code> / <code>just npm-publish</code> commands.
- The same auth checks now run early in <code>check_prerequisites</code> as non-fatal warnings, so credential problems surface before the release work starts.
- Kept the existing per-package y/N confirmations and verify URLs, and updated the dry-run branch to describe the new checks and retry behavior.
- All prompts (including the new Retry / Skip / Abort prompt) read via <code>$stdin.gets</code>, never bare <code>gets</code>, preserving the earlier ARGF fix for version arguments in ARGV.
- Added a CHANGELOG entry under a new <code>[Unreleased]</code> section.

Verified with <code>ruby -c</code>, a full <code>--dry-run</code> pass, and scripted interactive runs covering every new branch: pre-check pass/fail for both registries, publish failure → Retry → Skip, invalid input re-prompt, Abort (exit 1), and the skipped-package gate (continue on y, exit on default n).

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

https://claude.ai/code/session_01Xn94Xq3uGnCck8f3KB9VyT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn94Xq3uGnCck8f3KB9VyT)_