### PR TITLE
feat(Release): Automate CHANGELOG finalization in bin/release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `## [Unreleased]` heading with `## [VERSION] - YYYY-MM-DD` itself and shows the resulting diff before the
   existing commit confirmation, instead of opening `$EDITOR` for a manual edit. It skips with an INFO message
   when the version section already exists and falls back to offering `$EDITOR` when there is no
-  `[Unreleased]` section.
+  `[Unreleased]` section. The prerequisites step now verifies `CHANGELOG.md` exists up front so the update
+  step can assume it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ project "released" until that point in time.
 We plan to use patch versions only for bug fixes, and for now, all **minor releases** should be considered
 **breaking**!
 
+## [Unreleased]
+
+### Tooling & Standards
+
+- feat(Release): Automate the CHANGELOG finalization step in `bin/release` — the wizard now replaces the
+  `## [Unreleased]` heading with `## [VERSION] - YYYY-MM-DD` itself and shows the resulting diff before the
+  existing commit confirmation, instead of opening `$EDITOR` for a manual edit. It skips with an INFO message
+  when the version section already exists and falls back to offering `$EDITOR` when there is no
+  `[Unreleased]` section.
+
 ## [0.6.0] - 2026-06-12
 
 ### Tooling & Standards

--- a/bin/release
+++ b/bin/release
@@ -94,6 +94,10 @@ def check_prerequisites(dry_run: false)
     puts "DRY RUN: Running read-only prerequisite checks..."
   end
 
+  # Track fatal prerequisite failures so every problem surfaces in one pass
+  # and the script still exits non-zero at the end.
+  prerequisites_ok = true
+
   # Check if we're on main branch (safe to run in dry run)
   current_branch = `git branch --show-current`.strip
   unless current_branch == 'main'
@@ -119,13 +123,22 @@ def check_prerequisites(dry_run: false)
   end
 
   # Check that CHANGELOG.md exists (the release wizard rewrites its
-  # [Unreleased] heading later, so a missing file is a hard blocker). Exit
-  # even in dry run since the CHANGELOG step would otherwise fail to read it.
+  # [Unreleased] heading later, so a missing file is a hard blocker). Flag it
+  # loudly but keep running; the deferred check at the end aborts with a
+  # failure code so the CHANGELOG step never reads a missing file.
   if File.exist?('CHANGELOG.md')
     puts "SUCCESS: CHANGELOG.md found"
   else
-    puts "ERROR: CHANGELOG.md not found in the project root."
-    exit 1
+    puts
+    puts "!" * 60
+    puts "ERROR: CHANGELOG.md not found in the project root!"
+    puts
+    puts "   The release wizard finalizes the CHANGELOG by rewriting its"
+    puts "   '## [Unreleased]' heading, so this file is required. Create it"
+    puts "   before running the release."
+    puts "!" * 60
+    puts
+    prerequisites_ok = false
   end
 
   # Warn early about missing publishing credentials so they can be fixed
@@ -144,6 +157,11 @@ def check_prerequisites(dry_run: false)
     if response == 'y'
       execute_command("Running all tests", "just test")
     end
+  end
+
+  unless prerequisites_ok
+    puts "ERROR: Required prerequisites are missing — aborting release."
+    exit 1
   end
 
   if dry_run

--- a/bin/release
+++ b/bin/release
@@ -158,16 +158,17 @@ def update_changelog(version, dry_run: false)
   puts "\nSTEP 2: Update CHANGELOG"
   puts "=" * 50
 
+  release_header = "## [#{version}] - #{Date.today.strftime('%Y-%m-%d')}"
+
   if dry_run
     puts "DRY RUN: Checking if CHANGELOG update is needed..."
 
-    # Check if CHANGELOG exists and has unreleased section
     if File.exist?('CHANGELOG.md')
       changelog_content = File.read('CHANGELOG.md')
-      if changelog_content.include?('[Unreleased]')
-        puts "INFO: CHANGELOG has [Unreleased] section that needs to be updated to [#{version}]"
-      elsif changelog_content.include?("[#{version}]")
+      if changelog_content.include?("[#{version}]")
         puts "SUCCESS: CHANGELOG already has [#{version}] section"
+      elsif changelog_content.include?('## [Unreleased]')
+        puts "INFO: Would replace '## [Unreleased]' with '#{release_header}'"
       else
         puts "WARNING: CHANGELOG missing both [Unreleased] and [#{version}] sections"
       end
@@ -177,23 +178,31 @@ def update_changelog(version, dry_run: false)
     return
   end
 
-  # Check if CHANGELOG already has the version
-  if File.exist?('CHANGELOG.md')
-    changelog_content = File.read('CHANGELOG.md')
-    if changelog_content.include?("[#{version}]")
-      puts "INFO: CHANGELOG already has [#{version}] section"
-      response = prompt_yes_no("Continue with existing CHANGELOG?", default: 'y')
-      return if response == 'y'
-    end
+  unless File.exist?('CHANGELOG.md')
+    puts "WARNING: CHANGELOG.md not found, skipping CHANGELOG update"
+    return
   end
 
-  puts "   Please update CHANGELOG.md to replace '[Unreleased]' with the new version header:"
-  puts "   ## [#{version}] - #{Date.today.strftime('%Y-%m-%d')}"
-  puts
+  changelog_content = File.read('CHANGELOG.md')
 
-  response = prompt_yes_no("Open CHANGELOG.md for editing?", default: 'y')
-  if response == 'y'
-    system("#{ENV['EDITOR'] || 'nano'} CHANGELOG.md")
+  if changelog_content.include?("[#{version}]")
+    puts "INFO: CHANGELOG already has [#{version}] section, skipping update"
+    return
+  end
+
+  if changelog_content.include?('## [Unreleased]')
+    puts "   Replacing '## [Unreleased]' with '#{release_header}'..."
+    File.write('CHANGELOG.md', changelog_content.sub('## [Unreleased]', release_header))
+
+    puts "\nCHANGES: Resulting CHANGELOG diff:"
+    system('git diff CHANGELOG.md')
+    puts
+  else
+    puts "WARNING: CHANGELOG.md has no '## [Unreleased]' section to replace."
+    response = prompt_yes_no("Open CHANGELOG.md for manual editing?", default: 'y')
+    if response == 'y'
+      system("#{ENV['EDITOR'] || 'nano'} CHANGELOG.md")
+    end
   end
 
   response = prompt_yes_no("Commit CHANGELOG changes?", default: 'y')

--- a/bin/release
+++ b/bin/release
@@ -118,6 +118,16 @@ def check_prerequisites(dry_run: false)
     puts "SUCCESS: No uncommitted changes"
   end
 
+  # Check that CHANGELOG.md exists (the release wizard rewrites its
+  # [Unreleased] heading later, so a missing file is a hard blocker). Exit
+  # even in dry run since the CHANGELOG step would otherwise fail to read it.
+  if File.exist?('CHANGELOG.md')
+    puts "SUCCESS: CHANGELOG.md found"
+  else
+    puts "ERROR: CHANGELOG.md not found in the project root."
+    exit 1
+  end
+
   # Warn early about missing publishing credentials so they can be fixed
   # before the release work starts. Non-fatal: publishing (step 6) re-checks
   # and offers a retry loop.
@@ -208,23 +218,14 @@ def update_changelog(version, dry_run: false)
   if dry_run
     puts "DRY RUN: Checking if CHANGELOG update is needed..."
 
-    if File.exist?('CHANGELOG.md')
-      changelog_content = File.read('CHANGELOG.md')
-      if changelog_content.include?("[#{version}]")
-        puts "SUCCESS: CHANGELOG already has [#{version}] section"
-      elsif changelog_content.include?('## [Unreleased]')
-        puts "INFO: Would replace '## [Unreleased]' with '#{release_header}'"
-      else
-        puts "WARNING: CHANGELOG missing both [Unreleased] and [#{version}] sections"
-      end
+    changelog_content = File.read('CHANGELOG.md')
+    if changelog_content.include?("[#{version}]")
+      puts "SUCCESS: CHANGELOG already has [#{version}] section"
+    elsif changelog_content.include?('## [Unreleased]')
+      puts "INFO: Would replace '## [Unreleased]' with '#{release_header}'"
     else
-      puts "WARNING: CHANGELOG.md not found"
+      puts "WARNING: CHANGELOG missing both [Unreleased] and [#{version}] sections"
     end
-    return
-  end
-
-  unless File.exist?('CHANGELOG.md')
-    puts "WARNING: CHANGELOG.md not found, skipping CHANGELOG update"
     return
   end
 


### PR DESCRIPTION
## Summary

The release wizard used to make the user finalize the CHANGELOG by hand: `update_changelog` printed "Please update CHANGELOG.md to replace '[Unreleased]' with the new version header", opened `$EDITOR`, and then committed. This automates that step so the script performs the edit itself.

## Changes

- **`bin/release` (`update_changelog`)**: The wizard now rewrites the `## [Unreleased]` heading to `## [VERSION] - YYYY-MM-DD` itself (using `Date.today`), then shows `git diff CHANGELOG.md` before the existing y/N commit confirmation. The commit message format is unchanged (`docs: Finalize CHANGELOG for release vVERSION`).
- **Edge cases preserved**: if the file already has a `[VERSION]` section, it skips with an INFO message; if there is no `## [Unreleased]` section at all, it warns and offers to open `$EDITOR` as a fallback.
- **Dry-run branch** updated to describe the new automated replace behavior ("Would replace '## [Unreleased]' with ...").
- All prompts continue to read from `$stdin.gets` rather than bare `gets`, keeping the previously-fixed ARGF bug at bay.
- **`CHANGELOG.md`**: added an `[Unreleased]` section documenting this change (v0.6.0 was just released).

## Testing

- `ruby -c bin/release` → Syntax OK.
- Verified the three branches against sample CHANGELOG content: replace (has `## [Unreleased]`), skip (already has `[VERSION]`), and fallback (neither section present) all behave as intended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUAJJ35oNaMhQjJU4QZJvT)_