### PR TITLE
fix(Demo): Remove vendor from Rails load path to fix SystemStackError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   can fix credentials in another terminal and retry without restarting the wizard. The same checks run as
   early non-fatal warnings in the prerequisites step, and the dry-run output describes the new behavior.
 
+### Fixed
+
+- fix(Demo): Drop `vendor` from the demo app's Rails load path to stop the intermittent `SystemStackError`
+  that crashed the Playwright CI job's production server boot. Rails adds `vendor` to `$LOAD_PATH` by default,
+  but ours holds only the `loco_motion-rails` symlink, which points back at the repo root and so makes
+  `vendor` a self-referential directory cycle (`vendor/loco_motion-rails` -> repo ->
+  `docs/demo/vendor/loco_motion-rails` -> ...). Bootsnap's path scanner follows symlinks with no cycle
+  detection, recursing until the call stack overflowed — whether it overflowed or merely wasted time depended
+  on the runner's stack size and path length, hence the flakiness. Bundler already loads the gem through its
+  own `lib`/`app` require paths, so nothing requireable lives in `vendor` and skipping it is safe.
+
 ## [0.6.0] - 2026-06-12
 
 ### Tooling & Standards

--- a/docs/demo/config/application.rb
+++ b/docs/demo/config/application.rb
@@ -18,6 +18,17 @@ module LocoDemo
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    # Drop `vendor` from the load path. Rails adds `vendor` to `$LOAD_PATH` by
+    # default, but ours holds only the `loco_motion-rails` symlink, which points
+    # back at the repo root (so the demo can use the gem via Bundler's `path:`).
+    # That makes `vendor` a self-referential directory cycle
+    # (vendor/loco_motion-rails -> repo -> docs/demo/vendor/loco_motion-rails ->
+    # ...). Bootsnap's path scanner follows the symlink and recurses until the
+    # boot crashes with `SystemStackError`. Bundler already adds the gem's own
+    # `lib`/`app` require paths, so nothing requireable lives in `vendor` and
+    # skipping it is safe.
+    config.paths["vendor"].skip_load_path!
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## Context

The demo app's production server boot was intermittently crashing with a `SystemStackError` during Playwright CI runs. The root cause is a self-referential symlink cycle in the `vendor` directory that Bootsnap's path scanner follows without cycle detection, causing unbounded recursion until the call stack overflows.

The demo app uses a `vendor/loco_motion-rails` symlink pointing back to the repo root so Bundler can load the gem via its `path:` directive. This creates a cycle: `vendor/loco_motion-rails` → repo root → `docs/demo/vendor/loco_motion-rails` → ... When Rails adds `vendor` to `$LOAD_PATH` by default, Bootsnap's path scanner follows the symlink and recurses infinitely. Whether it crashes or merely wastes time depends on the runner's stack size and path length, explaining the flakiness.

Since Bundler already loads the gem through its own `lib`/`app` require paths, nothing requireable actually lives in `vendor`, so skipping it is safe.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Added `config.paths["vendor"].skip_load_path!` to `docs/demo/config/application.rb` to prevent Rails from adding the `vendor` directory to `$LOAD_PATH`. This eliminates the symlink cycle that was causing Bootsnap to recurse infinitely during boot.

The fix is safe because:
- Bundler already adds the gem's `lib` and `app` directories to the load path
- No other code in `vendor` needs to be required
- The symlink is only needed for Bundler's path resolution, not Ruby's require mechanism

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have reviewed my own code for potential improvements

## Additional Notes

This is a minimal, targeted fix for a flaky CI issue. The change is configuration-only and requires no testing beyond verifying that the demo app boots successfully (which CI will confirm).

https://claude.ai/code/session_01CvZEMqjdyfUqbuSTchE9Je