### PR TITLE
fix(Demo): Restore 3D tilt on Hover Image Gallery example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `[Unreleased]` section. The prerequisites step now verifies `CHANGELOG.md` exists up front so the update
   step can assume it.
 
+### Demo / Docs Changes
+
+- fix(Demo): Fix the broken 3D tilt in the Hover 3D "3D Hover Image Gallery" example. The wrapper passed a
+  `block` display utility, which overrode DaisyUI's `display: inline-grid` on `.hover-3d` and collapsed the
+  eight hover zones that drive the tilt, so cards only scaled instead of rotating. Dropped `block` so the
+  grid (and the tilt) survive — the cards already lay out correctly as flex items without it.
+
 ### Fixed
 
 - fix(Demo): Drop `vendor` from the demo app's Rails load path to stop the intermittent `SystemStackError`

--- a/docs/demo/app/views/examples/daisy/layout/hovers.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/hovers.html.haml
@@ -48,5 +48,5 @@
 
   .flex.flex-wrap.justify-center.gap-6.py-4
     - %w[beach desert forest].each do |scene|
-      = daisy_hover(css: "block w-60") do
+      = daisy_hover(css: "w-60") do
         = daisy_figure(src: image_path("landscapes/#{scene}.jpg"), css: "rounded-2xl overflow-hidden h-40 [&>img]:size-full [&>img]:object-cover")


### PR DESCRIPTION
## Context

The last example on the Hover 3D demo page (`Daisy::Layout::HoverComponent`), titled "3D Hover Image Gallery", did not show the 3D tilt effect. Instead of tilting toward the cursor like the first two examples, each card only scaled up slightly on hover, making the example look broken.

The wrapper passed `css: "block w-60"`. The Tailwind `block` utility sets `display: block`, which overrides DaisyUI's `display: inline-grid` on `.hover-3d`. With the grid gone, the eight overlay "hover zones" (children 2–9) that drive the tilt collapse into zero-height blocks and never receive hover, so the `--transform` custom property stays at its default. The only hover rule still in effect is `.hover-3d:hover > :first-child { scale: 1.05 }` — exactly the "it just gets a little bigger" symptom. The two working examples never set a `display` utility, so they keep the grid.

## Related Issues

Fixes #147

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Dropped the `block` utility from the three "3D Hover Image Gallery" wrappers in <code>docs/demo/app/views/examples/daisy/layout/hovers.html.haml</code> (`css: "block w-60"` → `css: "w-60"`).
- The cards sit in a `flex flex-wrap` row and lay out correctly without `block` (flex items already blockify `inline-grid` to `grid`), so removing it lets `.hover-3d` keep DaisyUI's grid and restores the 3D tilt.
- Added a CHANGELOG entry under Demo / Docs Changes.

This is a demo-only fix; the `HoverComponent` itself is unchanged and correct.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Per the issue's optional suggestion, any consumer who passes a non-grid `display` utility (`block`, `flex`, …) to `daisy_hover` would break the effect the same way. Documenting/guarding that in `HoverComponent` is intentionally left out of this demo-only fix and can be a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXk6Nrkx47PGuHGYKHWZY3)_