### PR TITLE
fix(Demo): Stabilize Hover Gallery height with a fixed aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `[Unreleased]` section. The prerequisites step now verifies `CHANGELOG.md` exists up front so the update
   step can assume it.
 
+### Demo / Docs Changes
+
+- fix(Demo): Stop the Hover Gallery examples from jumping in height while hovering. The sample landscape
+  images have different aspect ratios, and DaisyUI leaves the gallery container at `height: auto`, so the
+  rendered height (and everything below it) shifted as each image became visible. Added `aspect-[3/2]` to
+  every `daisy_hover_gallery` wrapper so the height depends only on the width and `object-cover` crops each
+  image to fill the fixed box.
+
 ### Fixed
 
 - fix(Demo): Drop `vendor` from the demo app's Rails load path to stop the intermittent `SystemStackError`

--- a/docs/demo/app/views/examples/daisy/layout/hover_galleries.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/hover_galleries.html.haml
@@ -14,7 +14,7 @@
       Pass images via the `with_image` slot. Hover left and right over the
       gallery to reveal each image.
 
-  = daisy_hover_gallery(css: "max-w-60") do |gallery|
+  = daisy_hover_gallery(css: "max-w-60 aspect-[3/2]") do |gallery|
     - gallery.with_image(src: image_path("landscapes/beach.jpg"), alt: "Beach")
     - gallery.with_image(src: image_path("landscapes/desert.jpg"), alt: "Desert")
     - gallery.with_image(src: image_path("landscapes/forest.jpg"), alt: "Forest")
@@ -29,7 +29,7 @@
 
   = daisy_card(css: "card-sm bg-base-200 max-w-60 shadow") do |card|
     - card.with_top_figure do
-      = daisy_hover_gallery do |gallery|
+      = daisy_hover_gallery(css: "aspect-[3/2]") do |gallery|
         - gallery.with_image(src: image_path("landscapes/beach.jpg"), alt: "Beach")
         - gallery.with_image(src: image_path("landscapes/desert.jpg"), alt: "Desert")
         - gallery.with_image(src: image_path("landscapes/forest.jpg"), alt: "Forest")
@@ -44,7 +44,7 @@
       without a block. Useful for quick, uniform galleries.
 
   - srcs = %w[beach desert forest].map { |s| image_path("landscapes/#{s}.jpg") }
-  = daisy_hover_gallery(srcs: srcs, css: "max-w-60")
+  = daisy_hover_gallery(srcs: srcs, css: "max-w-60 aspect-[3/2]")
 
 
 = doc_example(title: "Hover Gallery with Custom Content") do |doc|
@@ -54,7 +54,7 @@
       content is rendered inside the figure. This allows full control over
       the inner markup.
 
-  = daisy_hover_gallery(css: "max-w-60") do
+  = daisy_hover_gallery(css: "max-w-60 aspect-[3/2]") do
     %img{ src: image_path("landscapes/beach.jpg"), alt: "Beach", class: "hover:opacity-100" }
     %img{ src: image_path("landscapes/desert.jpg"), alt: "Desert" }
     %img{ src: image_path("landscapes/forest.jpg"), alt: "Forest" }


### PR DESCRIPTION
## Context

On the Hover Gallery demo page (`Daisy::Layout::HoverGalleryComponent`), every example shifted the page layout while hovering across it. The sample landscape images have different aspect ratios, and DaisyUI's `hover-gallery` stacks all images in one grid row, toggling visibility with `opacity`, while leaving the container at `height: auto`. So the rendered height was driven by whichever image was currently laid out full-width — sweeping the cursor across a gallery changed its height (measured ~150px → ~163px on the first gallery), making the gallery and everything below it jump up and down.

DaisyUI already applies `object-fit: cover` to the images; the only missing piece was a stable container height.

## Related Issues

Fixes #148

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Added `aspect-[3/2]` to all four `daisy_hover_gallery` wrappers in <code>docs/demo/app/views/examples/daisy/layout/hover_galleries.html.haml</code> (Basic, in-a-Card, Shorthand, and Custom Content examples).
- With a fixed aspect ratio the gallery height depends only on its width, never on the visible image, and DaisyUI's `object-fit: cover` crops each image to fill the box — so hovering no longer reflows the page.
- Added a CHANGELOG entry under Demo / Docs Changes.

This is a demo-only fix; the `HoverGalleryComponent` itself is unchanged.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

The issue raises whether to bake a default `aspect-ratio` into `HoverGalleryComponent` itself. That is intentionally left out of this demo-only fix — it is a component-API decision worth its own discussion/PR, and `aspect-[3/2]` remains overridable via `css:`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXk6Nrkx47PGuHGYKHWZY3)_