### PR TITLE
fix(Demo): Contain FAB examples within their preview boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `[Unreleased]` section. The prerequisites step now verifies `CHANGELOG.md` exists up front so the update
   step can assume it.
 
+### Demo / Docs Changes
+
+- fix(Demo): Keep the FAB demo examples inside their own preview boxes. A FAB is `position: fixed`, so with
+  five on one page they all escaped to the viewport's bottom-right corner and their preview boxes collapsed
+  to 0px. Wrapped each example in a `relative` box with a fixed height (`h-48`) and a `[&_.fab]:absolute`
+  override so each FAB sits in the bottom-right of its own box; documented why on the demo page intro.
+
 ### Fixed
 
 - fix(Demo): Drop `vendor` from the demo app's Rails load path to stop the intermittent `SystemStackError`

--- a/docs/demo/app/views/examples/daisy/actions/fabs.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/fabs.html.haml
@@ -6,6 +6,11 @@
     (known as Speed Dial buttons) in a vertical arrangement or a flower
     shape (quarter circle).
 
+    Because a FAB is `position: fixed`, showing more than one on a page
+    requires a containing-block wrapper. Each example below is wrapped in
+    a `relative` box that overrides the FAB to `position: absolute` so it
+    sits in its own preview box instead of the viewport corner.
+
 
 = doc_example(title: "Simple FAB", comp: @comp) do |doc|
   - doc.with_description do
@@ -14,9 +19,10 @@
       button classes like `btn-primary`, `btn-circle`, and `btn-lg` to
       style the trigger.
 
-  = daisy_fab do |fab|
-    - fab.with_button(css: "btn-primary btn-circle btn-lg") do
-      = hero_icon "plus", css: "size-6"
+  %div.relative.w-full.h-48{ class: "[&_.fab]:absolute" }
+    = daisy_fab do |fab|
+      - fab.with_button(css: "btn-primary btn-circle btn-lg") do
+        = hero_icon "plus", css: "size-6"
 
 
 = doc_example(title: "FAB with Speed Dial", comp: @comp) do |doc|
@@ -26,15 +32,16 @@
       focused. Action buttons are rendered as standard
       `ButtonComponent` elements.
 
-  = daisy_fab do |fab|
-    - fab.with_button(css: "btn-primary btn-circle btn-lg") do
-      = hero_icon "plus", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = hero_icon "camera", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = hero_icon "photo", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = hero_icon "microphone", css: "size-6"
+  %div.relative.w-full.h-48{ class: "[&_.fab]:absolute" }
+    = daisy_fab do |fab|
+      - fab.with_button(css: "btn-primary btn-circle btn-lg") do
+        = hero_icon "plus", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = hero_icon "camera", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = hero_icon "photo", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = hero_icon "microphone", css: "size-6"
 
 
 = doc_example(title: "FAB Flower", comp: @comp) do |doc|
@@ -43,15 +50,16 @@
       Add the `fab-flower` CSS class to arrange the speed dial buttons
       in a quarter-circle (flower) pattern instead of a vertical stack.
 
-  = daisy_fab(css: "fab-flower") do |fab|
-    - fab.with_button(css: "btn-primary btn-circle btn-lg") do
-      = hero_icon "plus", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      A
-    - fab.with_action(css: "btn-circle btn-lg") do
-      B
-    - fab.with_action(css: "btn-circle btn-lg") do
-      C
+  %div.relative.w-full.h-48{ class: "[&_.fab]:absolute" }
+    = daisy_fab(css: "fab-flower") do |fab|
+      - fab.with_button(css: "btn-primary btn-circle btn-lg") do
+        = hero_icon "plus", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        A
+      - fab.with_action(css: "btn-circle btn-lg") do
+        B
+      - fab.with_action(css: "btn-circle btn-lg") do
+        C
 
 
 = doc_example(title: "FAB with Main Action", comp: @comp) do |doc|
@@ -60,15 +68,16 @@
       Add a `main_action` slot to show a primary action button when the
       FAB is opened. Use either `main_action` or `close`, not both.
 
-  = daisy_fab do |fab|
-    - fab.with_button(css: "btn-circle btn-lg") do
-      = heroicon "plus", css: "size-6"
-    - fab.with_main_action do
-      = daisy_button(css: "btn-primary") { "Save" }
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = heroicon "camera", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = heroicon "photo", css: "size-6"
+  %div.relative.w-full.h-48{ class: "[&_.fab]:absolute" }
+    = daisy_fab do |fab|
+      - fab.with_button(css: "btn-circle btn-lg") do
+        = heroicon "plus", css: "size-6"
+      - fab.with_main_action do
+        = daisy_button(css: "btn-primary") { "Save" }
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = heroicon "camera", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = heroicon "photo", css: "size-6"
 
 
 = doc_example(title: "Custom Activator", comp: @comp) do |doc|
@@ -78,10 +87,11 @@
       The `role="button"` and `tabindex="0"` attributes are
       automatically added for accessibility.
 
-  = daisy_fab do |fab|
-    - fab.with_activator(css: "btn btn-secondary btn-circle btn-lg") do
-      = hero_icon "heart", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = hero_icon "share", css: "size-6"
-    - fab.with_action(css: "btn-circle btn-lg") do
-      = hero_icon "bookmark", css: "size-6"
+  %div.relative.w-full.h-48{ class: "[&_.fab]:absolute" }
+    = daisy_fab do |fab|
+      - fab.with_activator(css: "btn btn-secondary btn-circle btn-lg") do
+        = hero_icon "heart", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = hero_icon "share", css: "size-6"
+      - fab.with_action(css: "btn-circle btn-lg") do
+        = hero_icon "bookmark", css: "size-6"


### PR DESCRIPTION
## Context

Every example on the FAB demo page (`Daisy::Actions::FabComponent`) rendered in the bottom-right corner of the viewport instead of inside its own example box. DaisyUI's `.fab` is `position: fixed` (correct for a real app, where there's one FAB per page), but the demo shows five FABs on one page and the preview wrapper does not establish a containing block for fixed-position descendants. So all five positioned themselves relative to the viewport and stacked in the same corner, and because `fixed` takes them out of flow, each `flex items-center justify-center` preview box collapsed to 0px.

A bare `position: relative` wrapper does not trap a `fixed` child — `fixed` ignores `relative` ancestors. The reliable fix (matching DaisyUI's own docs) is to override the FAB to `position: absolute` inside a `relative` wrapper that has an explicit height.

## Related Issues

Fixes #149

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Wrapped all five `daisy_fab` examples (Simple, Speed Dial, Flower, Main Action, Custom Activator) in <code>docs/demo/app/views/examples/daisy/actions/fabs.html.haml</code> in a `relative w-full h-48` box with a `[&_.fab]:absolute` override (the arbitrary-variant class is set via `class:` so HAML doesn't choke on the brackets). Each FAB now sits in the bottom-right of its own preview box, and the box no longer collapses.
- Added a short note to the demo page intro explaining that, because a FAB is `position: fixed`, demoing more than one on a page needs a containing-block wrapper.
- Added a CHANGELOG entry under Demo / Docs Changes.
- Verified the file compiles cleanly with HAML 6 (`Haml::Engine#call`).

This is a demo-presentation fix only; the `FabComponent`'s `position: fixed` is correct for real usage and is unchanged.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

I deliberately kept this fix in the example file rather than adding the containing block to the shared `DocExampleComponent` wrapper. Putting `transform`/`contain` on that wrapper would create a new containing block and stacking/clipping context for every example, which could clip or reposition components that legitimately overflow their box (dropdowns, tooltips, popovers) or portal out (modals).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXk6Nrkx47PGuHGYKHWZY3)_