### PR TITLE
docs(RunDemo): Point cloud-session guidance at bin/setup-docker

### DIFF
--- a/.claude/skills/run-demo/SKILL.md
+++ b/.claude/skills/run-demo/SKILL.md
@@ -2,9 +2,8 @@
 name: run-demo
 description: Boots the LocoMotion demo Rails app, serving it on port 3000.
   Uses Docker locally (via `just demo`) and a no-Docker rbenv/node fallback
-  in cloud sessions where Docker is unavailable. Use when the user says
-  "run the app", "start the demo", "boot the server", or as a prerequisite
-  before taking screenshots or videos.
+  for cloud sessions. Use when the user says "run the app", "start the demo",
+  "boot the server", or as a prerequisite before taking screenshots or videos.
 metadata:
   author: profoundry-us
   version: 1.0.0
@@ -19,8 +18,12 @@ Two execution paths exist depending on environment:
 
 - **Local development (default)** — use Docker via the `justfile`. Docker
   is installed locally; this matches the canonical dev workflow.
-- **Cloud sessions** — Docker is **not** available. Use the rbenv + Node
-  fallback documented below; setup is handled by the `SessionStart` hook.
+- **Cloud sessions** — Docker is installed but not started by default. You
+  have two options: run `bin/setup-docker` once to bootstrap the full
+  Docker-based `just` workflow (then Path A works exactly as it does
+  locally), or use the lighter no-Docker rbenv + Node fallback below (Path B)
+  to just serve the demo; that fallback's setup is handled by the
+  `SessionStart` hook.
 
 Detect which environment you are in via `CLAUDE_CODE_REMOTE`: if set to
 `true`, you are in a cloud session; otherwise you are local.
@@ -72,11 +75,13 @@ other process is holding port 3000 (`lsof -i :3000`).
 
 ## Path B — Cloud Sessions (no Docker)
 
-In cloud sessions Docker is unavailable, so the demo runs directly against
-the host's Ruby and Node. The `SessionStart` hook
-(`.claude/hooks/setup-demo.sh`) handles all heavy setup automatically on
-every session start: rbenv install, vendor symlink, `bundle install`,
-`db:prepare`, and JS dependency installation.
+This path runs the demo directly against the host's Ruby and Node — no
+Docker — which is the quickest way to just serve the demo in a cloud session.
+(To instead use the full Docker-based `just` workflow there, run
+`bin/setup-docker` once and follow Path A; see `CLAUDE.md`.) The
+`SessionStart` hook (`.claude/hooks/setup-demo.sh`) handles all heavy setup
+automatically on every session start: rbenv install, vendor symlink,
+`bundle install`, `db:prepare`, and JS dependency installation.
 
 ### Environment Notes (cloud only)
 


### PR DESCRIPTION
## Context

`bin/setup-docker` (added in #154) bootstraps the Docker-based `just` workflow in remote / cloud Claude Code sessions. That made the `run-demo` skill's standing claim that "Docker is **not** available" in cloud inaccurate — it was flagged as a follow-up in #154's own notes.

## Related Issues

Follow-up to #154.

## Type of Change

- [x] Documentation update

## Description

Updates `.claude/skills/run-demo/SKILL.md` so the cloud-session guidance reflects reality:

- Reframes cloud sessions as "Docker is installed but not started by default" rather than "not available."
- Documents the two options: run `bin/setup-docker` once for the full Docker `just` workflow (Path A then works exactly as locally), **or** use the lighter no-Docker rbenv/Node fallback (Path B) to just serve the demo.
- Updates the Path B intro and the frontmatter `description` to match.

Documentation only — no behavior change.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements

## Additional Notes

Skill-doc-only change (internal Claude tooling), so no CHANGELOG entry — the `bin/setup-docker` script and its `CLAUDE.md` docs landed in #154.