### PR TITLE
docs(Hover): Warn that display utilities break the 3D tilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   five on one page they all escaped to the viewport's bottom-right corner and their preview boxes collapsed
   to 0px. Wrapped each example in a `relative` box with a fixed height (`h-48`) and a `[&_.fab]:absolute`
   override so each FAB sits in the bottom-right of its own box; documented why on the demo page intro.
+- docs(Hover): Document that passing a `display` utility (`block`, `flex`) via `css:` overrides the
+  `hover-3d` effect's `display: inline-grid` and breaks the 3D tilt. Added a `@note` to the component's
+  YARD docs and a callout to the demo page intro, and corrected the YARD "Image Gallery" example that still
+  used `block`.
 
 ### Fixed
 

--- a/app/components/daisy/layout/hover_component.rb
+++ b/app/components/daisy/layout/hover_component.rb
@@ -20,6 +20,12 @@
 # interactive elements (buttons, links) inside the wrapper since they will
 # conflict with the hover zones.
 #
+# @note The `hover-3d` effect relies on DaisyUI's `display: inline-grid`.
+#   Passing a `display` utility such as `block` or `flex` via `css:` overrides
+#   it and collapses the eight hover zones, so the content only scales instead
+#   of tilting. Use sizing and spacing utilities (`w-60`, `max-w-100`, `m-4`)
+#   without changing `display`.
+#
 # @loco_example Basic Usage
 #   = daisy_hover(css: "max-w-100") do
 #     = daisy_figure(src: image_path("creditcard.webp"), css: "rounded-2xl overflow-hidden")
@@ -33,7 +39,7 @@
 # @loco_example Image Gallery
 #   .flex.gap-4
 #     - %w[card-1.webp card-2.webp card-3.webp].each do |img|
-#       = daisy_hover(css: "block w-60") do
+#       = daisy_hover(css: "w-60") do
 #         = daisy_figure(src: image_path(img), css: "rounded-2xl overflow-hidden")
 #
 module Daisy
@@ -54,6 +60,9 @@ module Daisy
       #   - Sizing: `w-96`, `max-w-md`
       #   - Spacing: `m-4`, `mx-2 my-12`
       #   - Cursor: `cursor-pointer` (recommended when also passing `href:`)
+      #
+      #   Avoid `display` utilities (`block`, `flex`); they override the
+      #   effect's `inline-grid` and break the tilt (see the note above).
       #
       # @option kws href [String] When provided, the wrapper renders as an `<a>`
       #   tag. Use this to make the entire 3D card clickable rather than placing

--- a/docs/demo/app/views/examples/daisy/layout/hovers.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/hovers.html.haml
@@ -8,6 +8,11 @@
     whole card to be clickable, pass an `href:` option so the wrapper is
     rendered as an `<a>` tag (the DaisyUI-recommended approach).
 
+    **Avoid `display` utilities in `css:`.** The effect relies on DaisyUI's
+    `display: inline-grid`; passing `block`, `flex`, or similar overrides it
+    and collapses the hover zones, so the content only scales instead of
+    tilting. Stick to sizing utilities like `w-60` or `max-w-100`.
+
 
 = doc_example(title: "Basic Hover 3D") do |doc|
   - doc.with_description do


### PR DESCRIPTION
## Context

DaisyUI`s `hover-3d` effect relies on `display: inline-grid`. Passing a `display` utility (`block`, `flex`) via `css:` overrides it and collapses the eight hover zones, so the content only scales instead of tilting — the exact root cause behind #147. Per the discussion on that fix, we document the pitfall rather than guard the component (a guard on `HoverComponent` could surprise users who legitimately want a different layout).

## Related Issues

Follow-up to #147 / #151.

## Type of Change

- [x] Documentation update

## Description

- Adds a `@note` to `HoverComponent`s YARD docs and a caution under the `css` `@option` describing the `display`-utility pitfall.
- Corrects the "Image Gallery" `@loco_example`, which still demonstrated the bug with `css: "block w-60"`.
- Adds a matching callout to the Hover 3D demo page intro.
- Logs the change under **Demo / Docs Changes** in the CHANGELOG.

Documentation only — no behavior change.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed (hover_component_spec: 10 examples, 0 failures)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project`s documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Deliberately keeps `HoverComponent` unguarded by design — it just warns about the footgun. The companion PR adds a default aspect ratio to `HoverGalleryComponent` (the #148 root-cause fix).