### PR TITLE
feat(HoverGallery): Add a default 3:2 aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `NODE_EXTRA_CA_CERTS` into a local `ruby:3.4.4` base so in-container HTTPS verifies, then builds and starts
   the `loco` and `demo` containers. Idempotent and a no-op locally; documented in `CLAUDE.md`.
 
+### Components Changes
+
+- feat(HoverGallery): Give `HoverGalleryComponent` a default 3:2 aspect ratio so galleries with mixed-aspect
+  images no longer shift height as each image is revealed on hover. The default uses DaisyUI's
+  zero-specificity `where:aspect-[3/2]` and is skipped when you pass your own `aspect-*` utility via `css:`,
+  so it stays easy to override. The demo examples drop their now-redundant explicit `aspect-[3/2]`.
+
 ### Demo / Docs Changes
 
 - fix(Demo): Fix the broken 3D tilt in the Hover 3D "3D Hover Image Gallery" example. The wrapper passed a

--- a/app/components/daisy/layout/hover_gallery_component.rb
+++ b/app/components/daisy/layout/hover_gallery_component.rb
@@ -10,6 +10,13 @@
 # creates invisible columns over the figure; hovering each column reveals the
 # corresponding image.
 #
+# @note By default the gallery is rendered with a 3:2 aspect ratio
+#   (`where:aspect-[3/2]`) so that images with differing aspect ratios don't
+#   shift the container's height as they are revealed on hover. The default
+#   uses DaisyUI's zero-specificity `where:` variant and is skipped entirely
+#   when you pass your own `aspect-*` utility (e.g. `aspect-square`) via
+#   `css:`, so it is easy to override.
+#
 # @slot image+ One or more images to display in the gallery. Each image
 #   accepts `src:` and `alt:` keyword arguments along with any standard HTML
 #   attribute via `html:`.
@@ -65,11 +72,14 @@ module Daisy
       #   images are added via `with_image`.
       #
       # @option kws css [String] Additional CSS classes for styling. Common
-      #   options include sizing utilities such as `max-w-60` or `w-full`.
+      #   options include sizing utilities such as `max-w-60` or `w-full`. Pass
+      #   an `aspect-*` utility (e.g. `aspect-square`) to override the default
+      #   3:2 aspect ratio.
       #
       def initialize(srcs: nil, **kws)
         super(**kws)
         @srcs = srcs
+        @css = config_option(:css, "")
       end
 
       def before_render
@@ -82,6 +92,12 @@ module Daisy
       def setup_component
         set_tag_name(:component, :figure)
         add_css(:component, "hover-gallery")
+
+        # Default to a 3:2 aspect ratio so images with different aspect
+        # ratios don't shift the gallery's height as each is revealed on
+        # hover. The zero-specificity `where:` variant plus this guard keep
+        # it easy to override; pass any `aspect-*` utility via `css:`.
+        add_css(:component, "where:aspect-[3/2]") unless @css.include?("aspect-")
       end
     end
   end

--- a/docs/demo/app/views/examples/daisy/layout/hover_galleries.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/hover_galleries.html.haml
@@ -14,7 +14,7 @@
       Pass images via the `with_image` slot. Hover left and right over the
       gallery to reveal each image.
 
-  = daisy_hover_gallery(css: "max-w-60 aspect-[3/2]") do |gallery|
+  = daisy_hover_gallery(css: "max-w-60") do |gallery|
     - gallery.with_image(src: image_path("landscapes/beach.jpg"), alt: "Beach")
     - gallery.with_image(src: image_path("landscapes/desert.jpg"), alt: "Desert")
     - gallery.with_image(src: image_path("landscapes/forest.jpg"), alt: "Forest")
@@ -29,7 +29,7 @@
 
   = daisy_card(css: "card-sm bg-base-200 max-w-60 shadow") do |card|
     - card.with_top_figure do
-      = daisy_hover_gallery(css: "aspect-[3/2]") do |gallery|
+      = daisy_hover_gallery do |gallery|
         - gallery.with_image(src: image_path("landscapes/beach.jpg"), alt: "Beach")
         - gallery.with_image(src: image_path("landscapes/desert.jpg"), alt: "Desert")
         - gallery.with_image(src: image_path("landscapes/forest.jpg"), alt: "Forest")
@@ -44,7 +44,7 @@
       without a block. Useful for quick, uniform galleries.
 
   - srcs = %w[beach desert forest].map { |s| image_path("landscapes/#{s}.jpg") }
-  = daisy_hover_gallery(srcs: srcs, css: "max-w-60 aspect-[3/2]")
+  = daisy_hover_gallery(srcs: srcs, css: "max-w-60")
 
 
 = doc_example(title: "Hover Gallery with Custom Content") do |doc|
@@ -54,7 +54,7 @@
       content is rendered inside the figure. This allows full control over
       the inner markup.
 
-  = daisy_hover_gallery(css: "max-w-60 aspect-[3/2]") do
+  = daisy_hover_gallery(css: "max-w-60") do
     %img{ src: image_path("landscapes/beach.jpg"), alt: "Beach", class: "hover:opacity-100" }
     %img{ src: image_path("landscapes/desert.jpg"), alt: "Desert" }
     %img{ src: image_path("landscapes/forest.jpg"), alt: "Forest" }

--- a/spec/components/daisy/layout/hover_gallery_component_spec.rb
+++ b/spec/components/daisy/layout/hover_gallery_component_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe Daisy::Layout::HoverGalleryComponent, type: :component do
     end
   end
 
+  context "default aspect ratio" do
+    it "applies a default aspect ratio to prevent hover height shift" do
+      render_inline(described_class.new)
+      expect(page).to have_selector("figure.hover-gallery[class*='aspect-']")
+    end
+
+    it "omits the default when a custom aspect ratio is supplied" do
+      render_inline(described_class.new(css: "aspect-square"))
+      expect(page).to have_selector("figure.hover-gallery[class*='aspect-square']")
+      expect(page).not_to have_selector("figure[class*='3/2']")
+    end
+  end
+
   context "with custom HTML attributes" do
     before do
       render_inline(described_class.new(html: { id: "my-gallery", data: { test: "value" } }))


### PR DESCRIPTION
## Context

`HoverGalleryComponent` rendered its `<figure>` at `height: auto`, so a gallery whose images have different aspect ratios shifted height (pushing down everything below it) as each image was revealed on hover — the root cause of #148. PR #152 patched this per-demo by adding `aspect-[3/2]` to every `daisy_hover_gallery` wrapper. This moves the fix into the component so every consumer benefits without remembering to add the class.

## Related Issues

Root-cause fix for #148 (PR #152 was the demo-only workaround).

## Type of Change

- [x] Component update/addition

## Description

- `HoverGalleryComponent` now applies a default `where:aspect-[3/2]` to the figure in `setup_component`.
- It uses DaisyUI`s zero-specificity `where:` variant **and** is skipped entirely when the caller passes their own `aspect-*` utility (`unless @css.include?("aspect-")`), so it is trivially overridable — the same pattern `Hero::IconComponent` uses for its default `size-5`.
- YARD `@note` and the `css` `@option` document the default and how to override it.
- The demo examples drop their now-redundant explicit `aspect-[3/2]`, demonstrating the default.
- Two new specs cover the default and the override guard.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (1195 examples, 0 failures)
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project`s documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Verified in the running demo: every gallery `<figure>` renders with `where:aspect-[3/2]` (including the card example that passes no `css:`), and Tailwind generates the zero-specificity rule `.where\:aspect-\[3\/2\] { :where(&) { aspect-ratio: 3/2 } }`, so a user-supplied `aspect-square` overrides it cleanly. Companion docs PR #156 documents the related `display`-utility pitfall on `HoverComponent`.