### PR TITLE
docs(Guides): Reconcile Install, Getting Started, and Docker overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `hover-3d` effect's `display: inline-grid` and breaks the 3D tilt. Added a `@note` to the component's
   YARD docs and a callout to the demo page intro, and corrected the YARD "Image Gallery" example that still
   used `block`.
+- docs(Guides): Reconcile overlap between the Install, Getting Started, and Docker guides left over from
+  folding the README in. The Docker guide is now scoped to environment setup only (install Docker, copy the
+  config files, `just dev` / `just dev-shell`) and ends by pointing at Getting Started, which owns the
+  app-creation flow (`rails new`, database config, running the app). The duplicated Tailwind 4 + DaisyUI CSS
+  block was removed from Getting Started, which now links to the Install guide as the canonical source.
 
 ### Fixed
 

--- a/docs/demo/app/views/guides/01_docker.html.haml
+++ b/docs/demo/app/views/guides/01_docker.html.haml
@@ -82,93 +82,16 @@
 
 .prose.mt-12
   :markdown
-    ## 4. Creating a Rails Application
+    ## Next: Create Your App
 
-    Once inside the development container, you can create a new Rails application:
+    With the containers built and a shell open via `just dev-shell`, your
+    development environment is ready — consistent across any OS, simple to
+    debug, and isolated from your host system's dependencies.
 
-.max-w-prose.mt-4
-  = daisy_code(prefix: "$") do
-    cd /home/app && rails new . --skip --database=postgresql --javascript=esbuild --css=tailwind
-
-.max-w-prose.mt-4
-  :markdown
-    If you run into trouble with the Rails command, you can reset the files and
-    try again by running the following `rm` command:
-
-  = daisy_code(css: "mt-4", prefix: "$") do
-    rm -rf .dockerignore .git .gitattributes .gitignore .node-version .ruby-version Gemfile README.md Rakefile app bin config config.ru
-
-.prose.mt-12
-  :markdown
-    ## 5. Database Configuration
-
-    After creating your Rails application, update the database configuration in
-    `config/database.yml`:
-
-  = doc_code(language: "yaml") do
-    :plain
-      # Under the default section in config/database.yml
-      host: db
-      username: postgres
-      password: password
-
-.prose.mt-12
-  :markdown
-    ## 6. Running Your Application
-
-    Now you can uncomment the `app` section in your `docker-compose.yml` file and
-    start your application:
-
-.max-w-prose
-  = daisy_code(css: "my-4", prefix: "$") do
-    just app
-
-.prose
-  :markdown
-    After the application builds and starts, you should see output indicating that
-    Rails is running. You can now visit [http://localhost:3000](http://localhost:3000)
-    in your web browser to see your application.
-
-.max-w-prose.mt-6
-  = doc_note do
-    :markdown
-      Once the container is built, you can run `just app-fast` to simply start
-      the containers. This is **much** faster than running the full build every
-      time.
-
-.prose.mt-12
-  :markdown
-    ## 7. Building JavaScript and CSS
-
-    To ensure JavaScript and CSS assets are properly bundled, update your
-    `Procfile.dev` to bind to all interfaces:
-
-  = doc_code(language: "text") do
-    :plain
-      web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0
-
-.prose
-  :markdown
-    Also update your `Dockerfile` to use Foreman for starting the application:
-
-  = doc_code(language: "dockerfile") do
-    :plain
-      # Change this line:
-      CMD ["rails", "server", "-b", "0.0.0.0"]
-
-      # To this:
-      CMD ["./bin/dev"]
-
-  :markdown
-    ## Success!
-
-    You now have a complete Docker development environment for your Rails
-    application! This setup provides:
-
-    - Consistent development environment across any OS or system
-    - Simple debugging and troubleshooting
-    - Easy onboarding for new team members
-    - Isolation from your host system's dependencies
+    From here, the [Getting Started guide](#{guide_path("getting_started")})
+    picks up exactly where this one leaves off: creating the Rails app with
+    `rails new`, configuring the database, and applying the
+    LocoMotion-recommended setup (UUIDs, HAML, DaisyUI, and more).
 
 = daisy_divider
 

--- a/docs/demo/app/views/guides/01_getting_started.html.haml
+++ b/docs/demo/app/views/guides/01_getting_started.html.haml
@@ -194,28 +194,10 @@
 
 .mt-6.prose
   :markdown
-    Then add the `@import` and `@plugin` directives to your
-    `application.tailwind.css`:
-
-.mt-6.max-w-prose
-  = doc_code(language: "css") do
-    :plain
-      /* Import the base Tailwind theme */
-      @import 'tailwindcss';
-
-      /* Include DaisyUI via @plugin directive */
-      @plugin 'daisyui' {
-        themes: light --default, dark --prefersdark;
-      }
-
-      /* Custom variant to reduce selector specificity for component defaults */
-      @custom-variant where (:where(&));
-
-      /* Custom dark: variant for System-based & DaisyUI ThemeController dark mode */
-      @custom-variant dark (@media (prefers-color-scheme: dark), :root:has(input.theme-controller[value=dark]:checked) &);
-
-      /* Point to tailwind.config.js for content scan paths only */
-      @config "../tailwind.config.js";
+    Then add the Tailwind 4 + DaisyUI directives to your
+    `application.tailwind.css` — import Tailwind, register the DaisyUI plugin,
+    and add the `where` and `dark` custom variants. The
+    [Install guide](#{doc_path("install")}) lists the exact CSS block to copy.
 
 = doc_note(modifier: :warning, title: "Tailwind 4 Configuration", css: "mt-6") do
   :markdown


### PR DESCRIPTION
## Context

Folding the README into the guides left a lot of overlap between the three setup guides:

- **Getting Started ↔ Docker** repeated four whole sections verbatim — `rails new --css=tailwind` plus the reset `rm`, the `config/database.yml` block, uncomment-`app` / `just app` / `app-fast`, and the `Procfile.dev` + `Dockerfile` `CMD ["./bin/dev"]` change.
- **Install ↔ Getting Started** duplicated the Tailwind 4 + DaisyUI CSS block (`@import 'tailwindcss'` / `@plugin 'daisyui'` / `@custom-variant`).

Getting Started already framed Docker as a prerequisite ("follow the Docker guide first … once you can run `just dev` … come back here"), so the intended split was **Docker = environment, Getting Started = app creation** — the Docker guide just never got trimmed after the README merge.

## Related Issues

None — cleanup of README-into-guides overlap.

## Type of Change

- [x] Documentation update

## Description

- **Docker guide** is now scoped to environment setup only: install Docker, copy the example config files, and `just dev` / `just dev-shell`. The duplicated app-creation tail is replaced with a short "Next: Create Your App" pointer to the Getting Started guide.
- **Getting Started guide** keeps the full app-creation flow (it is now the single owner of `rails new`, database config, running the app, etc.). Its DaisyUI step no longer duplicates the Tailwind CSS block — it links to the **Install guide** as the canonical source.
- **Install guide** is unchanged: it remains the canonical home for the Tailwind 4 + DaisyUI CSS configuration that Getting Started now points to.

Net change is mostly deletion (+17 / −107).

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed (home-page e2e unaffected; there are no guide-content tests)
- [x] I have verified my changes in the browser (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Verified against the running demo: `/guides/docker`, `/guides/getting_started`, and `/docs/install` all render (HTTP 200), the Docker guide now links to Getting Started, Getting Started links to the Install guide, and the duplicated CSS block is gone. No content was lost — every section removed from the Docker guide already exists (and is more complete) in Getting Started.