### PR TITLE
docs(Install): Refresh install instructions for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   config files, `just dev` / `just dev-shell`) and ends by pointing at Getting Started, which owns the
   app-creation flow (`rails new`, database config, running the app). The duplicated Tailwind 4 + DaisyUI CSS
   block was removed from Getting Started, which now links to the Install guide as the canonical source.
+- docs(Install): Refresh the install instructions for v0.6.0. Bumped the stale `~> 0.5.2` gem pin (which
+  excluded 0.6.0) to `~> 0.6.0` in the README and the Install guide, refreshed the README's "v0.5.x" status
+  note and the `CLAUDE.md` version reference, and trimmed the README's duplicated install walkthrough to a
+  quickstart that points at the Install guide as the canonical source (the `bundle show` gotcha moved into
+  that guide).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 
 ## Project Overview
 
-LocoMotion is a Rails ViewComponent library (v0.5.2) that wraps DaisyUI
+LocoMotion is a Rails ViewComponent library (v0.6.0) that wraps DaisyUI
 components with a clean Ruby API. It generates semantic, accessible UI
 elements using Tailwind CSS classes and ships with a live demo application
 for previewing and testing every component.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ opinionated project setup, start with the [Guides](#guides).
 
 This project is in active development and many changes occur with every release!
 
-As of **v0.5.x**, LocoMotion ships with **Tailwind 4** and **DaisyUI 5**. The
-install approach has changed from previous versions, so please follow the
-updated instructions below.
+As of **v0.6.x**, LocoMotion ships with **Tailwind 4** and **DaisyUI 5**. The
+install approach changed with Tailwind 4, so be sure to follow the current
+installation instructions below.
 
 > [!CAUTION]
 > LocoMotion is in active development. Components are functional but APIs may
@@ -66,77 +66,18 @@ them in real projects.
 
 ## Installation
 
-Add the following to your `Gemfile` and re-run `bundle`:
+Add the gem to your `Gemfile` and run `bundle`:
 
 ```ruby
 # Gemfile
-
-gem "loco_motion-rails", "~> 0.5.2", require: "loco_motion"
+gem "loco_motion-rails", "~> 0.6.0", require: "loco_motion"
 ```
 
-Next, create or update your `tailwind.config.js` to tell Tailwind where to
-scan for component class names. In Tailwind 4, this file handles **only**
-content paths — plugins belong in your CSS file (see the
-[Getting Started guide](https://loco-motion.profoundry.us/guides/getting_started)).
-
-```js
-const { execSync } = require('child_process');
-let locoBundlePath =
-  execSync('bundle show loco_motion-rails').toString().trim();
-
-module.exports = {
-  content: [
-    `${locoBundlePath}/app/components/**/*.{rb,js,html,haml}`,
-    'app/components/**/*.{rb,js,html,haml}',
-    'app/views/**/*.{rb,js,html,haml}',
-  ]
-}
-```
-
-> [!WARNING]
-> Note that `bundle show loco_motion-rails` will output nothing if the gem
-> is not installed or the name is wrong, causing Tailwind to skip all
-> component classes. Make sure the gem name matches exactly.
-
-Next, if you're using any of the components that require JavaScript (like the
-Countdown component), you'll need to add the library as a dependency and include
-those controllers in your `application.js` file.
-
-```sh
-npm add @profoundry-us/loco_motion
-```
-
-or
-
-```sh
-yarn add @profoundry-us/loco_motion
-```
-
-Then inside your `application.js` file, make sure to import and register the
-relevant controllers.
-
-```js
-import { Application } from "@hotwired/stimulus"
-
-import {
-  CountdownController,
-  ThemeController,
-  AlertController,
-  CallyInputController
-} from "@profoundry-us/loco_motion"
-
-const application = Application.start()
-
-// Register each controller under its `loco-*` Stimulus identifier. These
-// names are required: the components render `data-controller="loco-..."`, so
-// registering under any other name means the controller never connects.
-application.register("loco-countdown", CountdownController)
-application.register("loco-theme", ThemeController)
-application.register("loco-alert", AlertController)
-application.register("loco-cally-input", CallyInputController)
-
-export { application }
-```
+Some components also need a JavaScript package (for their Stimulus controllers)
+and a small Tailwind 4 / DaisyUI configuration. For the complete setup — the
+JavaScript install, Stimulus controller registration, and the Tailwind
+content-path and CSS directives — follow the
+[Install guide](https://loco-motion.profoundry.us/docs/install).
 
 ## Using Components
 

--- a/docs/demo/app/views/docs/02_install.html.haml
+++ b/docs/demo/app/views/docs/02_install.html.haml
@@ -24,7 +24,7 @@
   = doc_code(language: "ruby") do
     :plain
       # Gemfile
-      gem "loco_motion-rails", "~> 0.5.2", require: "loco_motion"
+      gem "loco_motion-rails", "~> 0.6.0", require: "loco_motion"
 
   :markdown
     Or if you want the latest and greatest:
@@ -144,6 +144,12 @@
           'app/views/**/*.{rb,js,html,haml}',
         ]
       }
+
+= doc_note(css: "mt-6", modifier: :warning, title: "Gem Name Must Match") do
+  :markdown
+    `bundle show loco_motion-rails` outputs nothing if the gem is not installed
+    or the name is wrong, which makes Tailwind silently skip every component
+    class. Make sure the gem name matches exactly.
 
 .mt-4.prose
   :markdown


### PR DESCRIPTION
## Context

After the 0.6.0 release the install docs were both **stale** and **duplicated**:

- The README and the Install guide both pinned `gem "loco_motion-rails", "~> 0.5.2"`. Because `~> 0.5.2` means `>= 0.5.2, < 0.6.0`, that pin **excludes the released 0.6.0** — anyone following the docs installs an old version.
- The README still said "As of **v0.5.x**", and `CLAUDE.md` described the project as `(v0.5.2)`.
- The README's `## Installation` section carried a full walkthrough (gem, `tailwind.config.js`, JS controller registration) that duplicated the Install guide — the same README-into-guides overlap as #158 / #73, just in the README itself.

The release process (`bin/release`) bumps `version.rb` / `VERSION` / npm but not these prose/snippet references, so they drift stale each release.

## Related Issues

Follow-up to the README-into-guides migration (#73) and the guide reconciliation (#158).

## Type of Change

- [x] Documentation update

## Description

- Bumped `~> 0.5.2` → `~> 0.6.0` in the README and the Install guide; refreshed the README "v0.5.x" status note and the `CLAUDE.md` version reference.
- Trimmed the README `## Installation` to a quickstart (add the gem + `bundle`) that links to the **Install guide** as the canonical source for the JavaScript install, Stimulus controller registration, and Tailwind/DaisyUI configuration (~65 lines of duplication removed).
- Preserved the useful "`bundle show loco_motion-rails` outputs nothing" gotcha by moving it into the Install guide's content-path section.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have verified my changes in the browser (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Verified the Install guide renders locally (`/docs/install` → 200, with the new warning note and the `~> 0.6.0` snippet) and the README's new link target is live (`https://loco-motion.profoundry.us/docs/install` → 200).

Noticed but **out of scope**: `bin/release` does not refresh these install-doc version references, which is why they drifted post-release. Worth teaching the release wizard (or a `just version-check`-style guard) to catch `~> X.Y` pins in the README and Install guide — happy to file a follow-up.