### PR TITLE
chore(Release): Keep install-doc gem pins in sync with the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   Hub pulls avoid the HTTP 429 rate limit), installs `just`, bakes the environment's egress-proxy CAs and
   `NODE_EXTRA_CA_CERTS` into a local `ruby:3.4.4` base so in-container HTTPS verifies, then builds and starts
   the `loco` and `demo` containers. Idempotent and a no-op locally; documented in `CLAUDE.md`.
+- chore(Release): Keep the documented `gem "loco_motion-rails", "~> X.Y.Z"` install pins in sync with the
+  released version. `bin/update_version` now rewrites the pins in `README.md` and the Install guide when it
+  bumps the version, and `bin/version-check` (`just version-check`) verifies those two pins alongside
+  `version.rb` / `VERSION` / the npm packages — so a stale pin (which silently excludes the new release, like
+  `~> 0.5.2` excluding 0.6.0) fails the check instead of shipping.
 
 ### Components Changes
 

--- a/bin/update_version
+++ b/bin/update_version
@@ -64,6 +64,32 @@ def update_version(new_version = nil)
       end
     end
 
+    # Update the documented `gem "loco_motion-rails", "~> X.Y.Z"` install pins
+    # so the README and Install guide track the released version. A stale pin
+    # silently excludes the new release (e.g. "~> 0.5.2" excludes 0.6.0), so
+    # new installs following the docs resolve to the previous minor series.
+    install_pin_files = [
+      'README.md',
+      File.join('docs', 'demo', 'app', 'views', 'docs', '02_install.html.haml')
+    ]
+    install_pin_files.each do |rel_path|
+      path = File.join(root_dir, rel_path)
+      next unless File.exist?(path)
+
+      # Read/write as UTF-8 explicitly: these docs contain non-ASCII bytes
+      # (em dashes, emoji), and a US-ASCII default external encoding would
+      # otherwise raise "invalid byte sequence" on the gsub.
+      content = File.read(path, encoding: 'UTF-8')
+      updated = content.gsub(
+        /(gem\s+["']loco_motion-rails["'],\s*["']~>\s*)\d+\.\d+\.\d+/,
+        "\\1#{new_version}"
+      )
+      next if updated == content
+
+      File.write(path, updated, encoding: 'UTF-8')
+      puts "✓ Updated install pin in #{rel_path}"
+    end
+
     puts "\nSuccessfully updated version to #{new_version}"
     puts "\n📋 Next steps for release:"
     puts "1. Review the changes: git diff"

--- a/bin/version-check
+++ b/bin/version-check
@@ -5,11 +5,21 @@ canonical=$(grep -o '".*"' lib/loco_motion/version.rb | tr -d '"')
 version_file=$(tr -d '[:space:]' < VERSION)
 pkg=$(grep -o '"version": *"[^"]*"' package.json | head -1 | sed -E 's/.*"version": *"([^"]*)".*/\1/')
 demo_dep=$(grep -o '"@profoundry-us/loco_motion": *"[^"]*"' docs/demo/package.json | head -1 | sed -E 's/.*: *"\^?([^"]*)".*/\1/')
+
+# The documented `gem "loco_motion-rails", "~> X.Y.Z"` install pins. These must
+# track the released version, or new installs following the docs resolve to the
+# previous minor series (e.g. a stale "~> 0.5.2" excludes 0.6.0).
+install_guide=docs/demo/app/views/docs/02_install.html.haml
+readme_pin=$(grep -oE 'loco_motion-rails", *"~> *[0-9]+\.[0-9]+\.[0-9]+' README.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+install_pin=$(grep -oE 'loco_motion-rails", *"~> *[0-9]+\.[0-9]+\.[0-9]+' "$install_guide" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+
 echo "version.rb (canonical):                  $canonical"
 echo "VERSION file:                            $version_file"
 echo "package.json:                            $pkg"
 echo "docs/demo/package.json (loco_motion dep): $demo_dep"
-if [ "$canonical" = "$version_file" ] && [ "$canonical" = "$pkg" ] && [ "$canonical" = "$demo_dep" ]; then
+echo "README install pin (~>):                 ${readme_pin:-<none>}"
+echo "Install guide install pin (~>):          ${install_pin:-<none>}"
+if [ "$canonical" = "$version_file" ] && [ "$canonical" = "$pkg" ] && [ "$canonical" = "$demo_dep" ] && [ "$canonical" = "$readme_pin" ] && [ "$canonical" = "$install_pin" ]; then
     echo "✓ All version sources agree ($canonical)"
 else
     echo "✗ Version mismatch! Run bin/update_version to sync them." >&2


### PR DESCRIPTION
## Context

This closes the loop on the install-doc version staleness fixed in #159 (the README and Install guide were pinned to `~> 0.5.2`, which excludes the released 0.6.0).

Root cause: `bin/update_version` bumps `version.rb` / `VERSION` / both `package.json`s but **not** the documented `gem "loco_motion-rails", "~> X.Y.Z"` install pins, and `bin/version-check` (`just version-check`) did not verify them — so they drift stale every release.

## Related Issues

Follow-up to #159 (the manual install-docs refresh).

## Type of Change

- [x] Other (please describe): release tooling

## Description

- **`bin/update_version`** now rewrites the `~> X.Y.Z` gem pin in `README.md` and `docs/demo/app/views/docs/02_install.html.haml` to the new version when it bumps a release. It reads/writes those files as UTF-8 explicitly — they contain em dashes / emoji, which would otherwise raise `invalid byte sequence` under a US-ASCII default external encoding (this actually bit me while testing on host Ruby).
- **`bin/version-check`** now also extracts and compares both install pins against the canonical version, so a stale pin fails the check with the existing `✗ Version mismatch!` message instead of shipping.

## Checklist

- [x] My code follows the code style of this project
- [x] All new and existing tests passed
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Tested locally:
- `just version-check` passes when all six sources agree; drifting a pin makes it exit 1 with `✗ Version mismatch!` and the offending pin shown.
- `bin/update_version 9.9.9` bumps all six sources including both pins (verified, then reverted).

`bin/**/*` is excluded from the CI RuboCop run, so these scripts are not linted; the added Ruby matches the file's existing single-quote style.

Scoped to the **gem pins** (the install-breaking part). The softer version *prose* ("v0.6.x" in the README, "(v0.6.0)" in `CLAUDE.md`) is intentionally left out — auto-rewriting prose is fragile, and a stale prose line does not break installs.