### PR TITLE
feat(Modal): Add trigger:false for a Global Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   images no longer shift height as each image is revealed on hover. The default uses DaisyUI's
   zero-specificity `where:aspect-[3/2]` and is skipped when you pass your own `aspect-*` utility via `css:`,
   so it stays easy to override. The demo examples drop their now-redundant explicit `aspect-[3/2]`.
+- feat(Modal): Add a `trigger: false` option that renders a "Global Modal" — just the `<dialog>` with no
+  built-in trigger button — so one modal can live in a layout and be opened from anywhere on the page (a
+  link, another component, or JavaScript). Also lets a call-time `html: { tabindex: -1 }` on the activator
+  override the default `tabindex="0"`, which the build-time default previously clobbered. Refs #161.
 
 ### Demo / Docs Changes
 

--- a/app/components/daisy/actions/modal_component.rb
+++ b/app/components/daisy/actions/modal_component.rb
@@ -21,7 +21,8 @@
 # @part end_actions Container for right (end) aligned action buttons.
 #
 # @slot activator A custom element that opens the modal. Automatically adds
-#   `role="button"` and `tabindex="0"` attributes for accessibility.
+#   `role="button"` and a default `tabindex="0"` for accessibility; pass
+#   `html: { tabindex: -1 }` (etc.) to override either default.
 # @slot button The button that opens the modal. Defaults to a standard Daisy
 #   button with the modal's title.
 # @slot close_icon A custom close button to replace the default 'X' icon.
@@ -69,6 +70,15 @@
 #       %form{ method: :dialog }
 #         = daisy_button { "Close" }
 #
+# @loco_example Global Modal
+#   = daisy_modal(title: "Settings", trigger: false, dialog_id: "app-modal") do |modal|
+#     %p This modal has no built-in trigger — open it from anywhere.
+#     - modal.with_end_actions do
+#       %form{ method: :dialog }
+#         = daisy_button { "Close" }
+#
+#   = daisy_button(html: { onclick: "document.getElementById('app-modal').showModal()" }) { "Open" }
+#
 module Daisy
   module Actions
     class ModalComponent < LocoMotion::BaseComponent
@@ -77,7 +87,7 @@ module Daisy
       define_parts :box, :actions, :close_icon_wrapper, :close_icon,
                    :backdrop, :title, :start_actions, :end_actions
 
-      renders_one :activator, LocoMotion::BasicComponent.build(html: { role: "button", tabindex: 0 })
+      renders_one :activator, LocoMotion::BasicComponent
       renders_one :button, Daisy::Actions::ButtonComponent
       renders_one :close_icon
       renders_one :title
@@ -87,6 +97,11 @@ module Daisy
       # @return [Boolean] Whether or not this dialog can be closed.
       attr_reader :closable
       alias closable? closable
+
+      # @return [Boolean] Whether or not a built-in trigger is rendered. When
+      #   false, only the `<dialog>` is rendered (a "Global Modal").
+      attr_reader :trigger
+      alias trigger? trigger
 
       # @return [String] The unique ID for the `<dialog>` element.
       attr_reader :dialog_id
@@ -112,11 +127,18 @@ module Daisy
       # @option kws dialog_id [String] A custom ID for the dialog element. If not
       #   provided, a unique ID will be generated.
       #
+      # @option kws trigger [Boolean] When true (default) and no custom activator
+      #   or button slot is given, a default button (labeled with the title) is
+      #   rendered to open the modal. Pass false to render only the `<dialog>`
+      #   with no built-in trigger — a "Global Modal" that you place once and
+      #   open from elsewhere (a link, another component, or JavaScript).
+      #
       def initialize(title = nil, **kws, &block)
         super
 
         @dialog_id = config_option(:dialog_id, SecureRandom.uuid)
         @closable = config_option(:closable, true)
+        @trigger = config_option(:trigger, true)
         @simple_title = config_option(:title, title)
       end
 
@@ -136,15 +158,26 @@ module Daisy
       private
 
       def setup_activator_or_button
+        element =
+          if activator?
+            activator
+          elsif button?
+            button
+          elsif trigger?
+            default_button
+          end
+
+        # Global Modal mode (`trigger: false`) with no activator or button has
+        # nothing to wire — render just the `<dialog>`.
+        return unless element
+
+        # Accessibility defaults for a custom activator live in the part's
+        # default HTML so a call-time `html:` (e.g. `tabindex: -1`) overrides
+        # them.
+        element.add_html(:component, role: "button", tabindex: 0) if activator?
+
         onclick = "document.getElementById('#{dialog_id}').showModal()"
-
-        element = if activator?
-                    activator
-                  else
-                    button || default_button
-                  end
-
-        element.add_html(:component, { onclick: onclick })
+        element.add_html(:component, onclick: onclick)
       end
 
       def setup_component

--- a/docs/demo/app/views/examples/daisy/actions/modals.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/modals.html.haml
@@ -64,3 +64,30 @@
           %form{ method: :dialog }
             = daisy_button do
               I'm Done
+
+%turbo-frame#global-modal
+  = doc_example(title: "Global Modal") do |doc|
+    - doc.with_description do
+      :markdown
+        Pass `trigger: false` to render the dialog on its own, with **no
+        built-in button**. Drop a single modal in your layout and open it from
+        anywhere on the page — a link, another component, or JavaScript.
+
+      = doc_note(css: "mb-8") do
+        Until the `loco-modal` Stimulus controller lands, open it however you
+        like. Here we use a small inline `onclick` for demonstration; a later
+        PR will replace this with a Stimulus action.
+
+    .flex.flex-col.items-center.gap-4
+      = daisy_button(css: "btn-primary", html: { onclick: "document.getElementById('global-demo').showModal()" }) do
+        Open Global Modal
+
+      = daisy_modal(title: "Global Modal", trigger: false, dialog_id: "global-demo") do |modal|
+        This modal has no built-in trigger. It was opened by a separate button
+        on the page — the same dialog could just as easily be opened from a
+        navbar, a table row, or anywhere else.
+
+        - modal.with_end_actions(css: "flex flex-row items-center gap-2") do
+          %form{ method: :dialog }
+            = daisy_button(css: "btn-primary") do
+              Close

--- a/docs/plans/202606-1-modal-global-dialog.md
+++ b/docs/plans/202606-1-modal-global-dialog.md
@@ -1,0 +1,318 @@
+# Modal: Global Dialog & Programmatic Open API
+
+## Overview
+
+This plan extends `Daisy::Actions::ModalComponent` so a single modal can live
+once in a layout, render with **no built-in trigger**, and be opened
+programmatically — including the canonical Hotwire pattern of lazy-loading a
+form into a `<turbo-frame>` and opening the dialog when the frame loads.
+
+It is split into **three dependency-ordered PRs**. Each PR ships its own
+tests **and** documentation (YARD + demo + guide updates) — documentation is
+not deferred to a follow-up.
+
+This is additive and backward compatible: the default modal (co-located
+button, opens on click via the existing inline `onclick`) renders and behaves
+exactly as it does today.
+
+
+## Related Issues
+
+- Implements
+  [#161](https://github.com/profoundry-us/loco_motion/issues/161) — Modal:
+  support a headless/standalone dialog with a programmatic open API.
+- Resolves the core of
+  [#16](https://github.com/profoundry-us/loco_motion/issues/16) — Modal
+  Component should use a Stimulus controller (currently labeled `wontfix` +
+  `needs investigation`; #161 is the concrete use case it was waiting on).
+- PRs A and B **reference** #161; PR C closes it with `Fixes #161`. All three
+  mention #16. Revisit the `wontfix` label on #16 once PR B lands.
+
+
+## Naming (decided)
+
+- **Flag: `trigger: false`** (default `trigger: true`). In the Hotwire
+  ecosystem a triggerless dialog is the *norm*, not a special mode, and
+  "trigger" is the standard word for the opener (Radix/shadcn `DialogTrigger`,
+  Bootstrap toggle/target) — so a plain boolean reads natively and does not
+  collide with the existing `activator` / `button` slot names.
+- **Documented pattern name: "Global Modal"** — the community term
+  (hotrails, AppSignal, bramjetten). Used in the demo example title and the
+  YARD `@loco_example` headings; the flag stays mechanical, the prose carries
+  the intent.
+- **Rejected:** `headless:` (collides with "Headless UI" = unstyled,
+  behavior-only components — the opposite of our fully-styled modal);
+  `standalone:` / `shared:` (invent a mode name the ecosystem does not use).
+- **Controller actions `open` / `close`** and the
+  `turbo:frame-load->loco-modal#open` / `turbo:submit-end->loco-modal#close`
+  wiring intentionally match `tailwindcss-stimulus-components` and
+  `@stimulus-components/dialog` so the API feels familiar.
+
+
+## Current Behavior (the gaps, with references)
+
+All in `app/components/daisy/actions/modal_component.rb` unless noted.
+
+1. **No triggerless render.** `setup_activator_or_button` resolves
+   `button || default_button`, and `default_button` calls
+   `with_button(simple_title)`, which *sets* the button slot — so the
+   template (`modal_component.html.haml:1-4`) always emits an activator or a
+   button. There is no way to render only the `<dialog>`.
+2. **No programmatic open API.** Line 139 hardcodes
+   `onclick="document.getElementById('#{dialog_id}').showModal()"`. No
+   Stimulus controller, no `open()` / `close()`.
+3. **No Turbo-frame integration.** Only inline content is supported.
+4. **No lifecycle events.** Nothing is emitted on open/close.
+5. **Activator `tabindex` cannot be overridden.** The slot is built with
+   `html: { role: "button", tabindex: 0 }` (line 80); a call-time
+   `tabindex: -1` loses the merge.
+
+
+## Design Principles
+
+- **Backward compatible.** Default rendering and behavior are unchanged. The
+  default co-located button keeps its inline `onclick` so existing apps need
+  no JavaScript registration.
+- **Opt-in controller.** A new `loco-modal` Stimulus controller powers the
+  open/close API, events, and Turbo-frame auto-open. It is attached to the
+  `<dialog>` but is **inert** if an app has not registered it — so it never
+  breaks a consumer who skips the JS step.
+- **Finish #16 later.** Migrating the *default* button off inline `onclick`
+  onto the controller is a small follow-up reserved for the next minor (minor
+  releases may break); it is out of scope here to keep these PRs non-breaking.
+- **Docs travel with code.** Every PR updates YARD, the demo example, and any
+  affected guide in the same PR.
+
+
+## PR A — Global Modal (`trigger: false`) + activator `tabindex` fix
+
+Pure Ruby/HAML. No JavaScript. Smallest, safest first step; removes the
+hidden-activator workaround from the issue.
+
+### A1. Component class
+
+**File:** `app/components/daisy/actions/modal_component.rb`
+
+- Add a `trigger` config option (default `true`); expose
+  `attr_reader :trigger` + `trigger?`.
+- In `setup_activator_or_button`, when `trigger?` is false: do **not** call
+  `default_button`, and skip adding the `onclick` when neither an `activator`
+  nor a `button` slot was supplied (no element to wire).
+- Fix gap #5: let a call-time `tabindex` win. Either drop `tabindex` from the
+  `renders_one :activator` build defaults and apply it in
+  `setup_activator_or_button` only when absent, or reverse the merge so
+  call-time `html:` takes precedence. Keep `role: "button"` and the default
+  `tabindex: 0` for the normal case.
+
+### A2. Template
+
+**File:** `app/components/daisy/actions/modal_component.html.haml`
+
+- The leading `if activator? / else = button` block already no-ops when
+  neither slot is set once `default_button` is suppressed — verify it renders
+  nothing in Global Modal mode and emits only `= part(:component)`.
+
+### A3. Spec
+
+**File:** `spec/components/daisy/actions/modal_component_spec.rb`
+
+- New context `"when trigger is false"`: renders `dialog.modal`, renders **no**
+  `button` and **no** activator, still renders the close icon and box.
+- New context: a call-time `activator` `tabindex: -1` is honored.
+
+### A4. Demo example
+
+**File:** `docs/demo/app/views/examples/daisy/actions/modals.html.haml`
+
+- Add a **"Global Modal"** example: a `daisy_modal(trigger: false,
+  dialog_id: "global-demo")` plus a separate button that opens it. Until the
+  controller lands (PR B), open it with a minimal inline
+  `onclick="document.getElementById('global-demo').showModal()"` and note in
+  the description that PR B will replace this with a Stimulus action.
+
+### A5. YARD
+
+**File:** `app/components/daisy/actions/modal_component.rb`
+
+- Add `@option kws trigger [Boolean]` describing the triggerless render, with
+  a blank line between entries.
+- Add an `@loco_example Global Modal` showing `trigger: false`.
+
+### A6. Verify
+
+```bash
+just loco-test
+just demo-test
+```
+
+Roughly 5 files, well under the 500-line / 10-file limit.
+
+
+## PR B — Stimulus Controller: `open` / `close` + lifecycle events
+
+Layers the clean JS API on top of Global Modal mode and gives #16 its
+controller.
+
+### B1. Controller
+
+**File (new):** `app/components/daisy/actions/modal_controller.js`
+
+- Mirror the existing `loco-*` controllers (see
+  `app/components/daisy/data_display/countdown_controller.js`).
+- Attached to the `<dialog>`; `this.element` is the dialog.
+- `open()` → `this.element.showModal()` then `this.dispatch("open")`
+  (emits `loco-modal:open`).
+- `close()` → `this.element.close()`.
+- In `connect()`, bind the dialog's native `close` event directly on
+  `this.element` (it does **not** bubble) and re-dispatch a bubbling
+  `loco-modal:close`; remove the listener in `disconnect()`.
+
+### B2. Component class
+
+**File:** `app/components/daisy/actions/modal_component.rb`
+
+- In `setup_component`, add `data-controller="loco-modal"` to the `:component`
+  part. This is additive and inert without registration. **Keep** the default
+  button's inline `onclick` (backward compat — see Design Principles).
+
+### B3. Register + document the controller
+
+- **Demo:** register `loco-modal` in
+  `docs/demo/app/javascript/controllers/index.js` next to the existing
+  controllers.
+- **Install guide:** update
+  `docs/demo/app/views/docs/02_install.html.haml` — add `ModalController`
+  to the import + `application.register("loco-modal", ModalController)`
+  snippet, with a one-line note that registration is required only to use the
+  modal's programmatic / Global Modal features.
+
+### B4. Demo example
+
+**File:** `docs/demo/app/views/examples/daisy/actions/modals.html.haml`
+
+- Update the PR A "Global Modal" example to open via the controller instead
+  of inline JS (e.g. `data: { action: "loco-modal#open" }` on an in-scope
+  trigger), and add a short snippet listening for `loco-modal:close`.
+
+### B5. e2e
+
+**File:** `docs/demo/e2e/daisy/actions/modals.spec.ts`
+
+- Add specs: programmatic open shows the dialog; `close()` hides it; the
+  `loco-modal:close` event fires. Run on chromium (see Caveats re: headless
+  WebKit and the `close` event).
+
+### B6. YARD
+
+- Document the `loco-modal` controller, the `open`/`close` actions, and the
+  `loco-modal:open` / `loco-modal:close` events on the component.
+
+### B7. Verify
+
+```bash
+just loco-test
+just demo-test
+docker compose exec -T demo yarn playwright test \
+  'e2e/daisy/actions/modals.spec.ts' --reporter dot --workers 1
+```
+
+Roughly 7 files. Single concern (the controller + its wiring).
+
+
+## PR C — Turbo-Frame Integration
+
+Builds on B; delivers the Global Modal pattern end to end.
+
+### C1. Component class
+
+**File:** `app/components/daisy/actions/modal_component.rb`
+
+- Add a `turbo_frame` config option. When present:
+  - render a `<turbo-frame id="...">` inside `:box` (or expose the id so the
+    consumer's frame is matched), and
+  - pass the frame id to the controller via a Stimulus value
+    (`data-loco-modal-turbo-frame-value`).
+
+### C2. Controller
+
+**File:** `app/components/daisy/actions/modal_controller.js`
+
+- Add `static values = { turboFrame: String }`.
+- On `connect()`, if a frame value is set, locate the frame and listen for
+  `turbo:frame-load` → `open()`.
+- On the dialog `close`, optionally clear the frame (`src`/contents) so
+  reopening refetches. Document this behavior.
+
+### C3. Spec
+
+**File:** `spec/components/daisy/actions/modal_component_spec.rb`
+
+- Context `"with a turbo_frame"`: renders a `turbo-frame` with the right id
+  inside the box and sets the controller value attribute.
+
+### C4. e2e
+
+**File:** `docs/demo/e2e/daisy/actions/modals.spec.ts`
+
+- A remote link targets the frame → frame loads → dialog opens; a successful
+  submit closes it. Use the idiomatic
+  `turbo:frame-load->loco-modal#open` / `turbo:submit-end->loco-modal#close`
+  wiring. Chromium only.
+
+### C5. Demo example
+
+**File:** `docs/demo/app/views/examples/daisy/actions/modals.html.haml`
+
+- Add a full "Global Modal (Turbo Frame)" example: a list of items whose
+  edit links carry `data-turbo-frame`, and one global
+  `daisy_modal(trigger: false, turbo_frame: "modal")`.
+- A tiny demo controller action may be needed to serve frame content; keep it
+  in the demo app only.
+
+### C6. YARD
+
+- Add `@option kws turbo_frame` and an `@loco_example` for the Turbo-frame
+  pattern.
+
+### C7. Verify
+
+```bash
+just loco-test
+just demo-test
+docker compose exec -T demo yarn playwright test \
+  'e2e/daisy/actions/modals.spec.ts' --reporter dot --workers 1
+```
+
+
+## Backward Compatibility
+
+- Default modal output and behavior are unchanged; existing specs pass as-is.
+- The `loco-modal` controller is inert until an app registers it; consumers
+  who skip the JS step keep working modals via the retained inline `onclick`.
+- `trigger:` and `turbo_frame:` are new optional params with backward-compatible
+  defaults.
+- Fully moving the default trigger off inline `onclick` (the remainder of #16)
+  is intentionally deferred to a future minor.
+
+
+## Caveats
+
+- **Headless WebKit `close` event.** Some headless WebKit builds do not fire
+  the `<dialog>` `close`/`cancel` events even though `showModal()`/`close()`
+  work (per the issue). Our Playwright suite runs **chromium**, so it is
+  unaffected — but keep e2e assertions about close/cancel on chromium and do
+  not port them to a WebKit project without revalidating.
+- If the demo does not reflect `.rb` / `.haml` changes during development,
+  restart it with `just demo-restart`.
+
+
+## Per-PR Size Check
+
+| PR | Concern | Approx. files |
+|----|---------|---------------|
+| A  | Global Modal mode + tabindex fix | ~5 |
+| B  | Stimulus controller + events | ~7 |
+| C  | Turbo-frame integration | ~7 |
+
+Each stays within the 500-line / 10-file limit and represents one logical
+concern.

--- a/spec/components/daisy/actions/modal_component_spec.rb
+++ b/spec/components/daisy/actions/modal_component_spec.rb
@@ -184,4 +184,55 @@ RSpec.describe Daisy::Actions::ModalComponent, type: :component do
       end
     end
   end
+
+  context "when trigger is false" do
+    let(:modal) { described_class.new(title: "Global", trigger: false) }
+
+    before do
+      render_inline(modal)
+    end
+
+    describe "rendering" do
+      it "still renders the dialog and box" do
+        expect(page).to have_css "dialog.modal .modal-box"
+      end
+
+      it "still renders the close icon" do
+        expect(page).to have_selector "dialog.modal svg"
+      end
+
+      it "does not render a trigger (no element is wired to open it)" do
+        expect(page).not_to have_css "[onclick]"
+      end
+    end
+  end
+
+  context "with a default activator" do
+    let(:modal) { described_class.new }
+
+    before do
+      render_inline(modal) do |m|
+        m.with_activator { "Open" }
+      end
+    end
+
+    it "adds role=button and a default tabindex=0" do
+      expect(page).to have_css '[role="button"][tabindex="0"]'
+    end
+  end
+
+  context "with an activator and an overridden tabindex" do
+    let(:modal) { described_class.new }
+
+    before do
+      render_inline(modal) do |m|
+        m.with_activator(html: { tabindex: -1 }) { "Open" }
+      end
+    end
+
+    it "lets the call-time tabindex win over the default" do
+      expect(page).to have_css '[role="button"][tabindex="-1"]'
+      expect(page).not_to have_css '[tabindex="0"]'
+    end
+  end
 end


### PR DESCRIPTION
## Context

While building a feature in another app, `daisy_modal` could not power the common Hotwire "global modal" pattern — a single modal placed once in the layout and opened by remote triggers elsewhere on the page — because it always renders a co-located trigger (a custom activator, an explicit button, or a generated default button). There was no way to render just the `<dialog>`.

This is **PR 1 of 3** from the plan in #161 (`docs/plans/202606-1-modal-global-dialog.md`). It adds the foundational triggerless render. The `loco-modal` Stimulus controller (open/close plus lifecycle events) and the Turbo-frame integration follow in PRs 2 and 3.

## Related Issues

Refs #161 — intentionally **not** `Fixes`, since the issue stays open until PR 3 of 3 lands. Also advances the core of #16 (move the modal off inline `onclick`), which PR 2 addresses with the Stimulus controller.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Component update/addition
- [x] Test update/addition

## Description

- **`trigger: false` ("Global Modal").** A new option on `Daisy::Actions::ModalComponent`. When `trigger: false` and no custom activator or button slot is given, the component renders **only** the `<dialog>` — no built-in opener — so you can place one modal in a layout and open it from anywhere (a link, another component, or JavaScript). Default (`trigger: true`) behavior is unchanged.
- **Activator `tabindex` fix.** The activator's `role="button"` / `tabindex="0"` defaults moved out of the slot's build-time html and into the part's default HTML, so a call-time `html: { tabindex: -1 }` now overrides them. Previously the build-time default won the merge and the override was silently ignored.
- **Docs + demo.** Added the `trigger` YARD `@option`, a "Global Modal" `@loco_example`, a demo example (opened by a separate button), and a CHANGELOG entry.

The naming (`trigger: false` flag plus "Global Modal" as the documented pattern) matches the Hotwire ecosystem, where a triggerless dialog is the norm and "trigger" is the standard word for the opener.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Verification: `bundle exec rspec spec` — 1200 examples, 0 failures (includes 5 new modal specs); `bundle exec rubocop` on the changed files — clean; `yarn playwright test e2e/daisy/actions/modals.spec.ts` — 4 passed (confirms the new example renders and existing modal behavior is intact).

This PR keeps the default button's inline `onclick`; fully migrating the default trigger onto the Stimulus controller (the remainder of #16) is deferred to a future minor, as noted in the plan.
