### PR TITLE
docs(Standards): Don't wrap GitHub-rendered text at 80 characters

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -82,6 +82,11 @@ Explain what is currently wrong, with code snippets if helpful.
 Point to any files or links that show the correct approach.
 ```
 
+Do NOT hard-wrap the issue body at 80 characters — GitHub reflows it as prose.
+Write natural paragraphs (one line each) and let them wrap on render. (Repo
+Markdown files still wrap at 80; this exception is only for text posted to
+GitHub.)
+
 Keep the title short and imperative: "Update X for Y", "Fix Z in W".
 
 ### Step 5: Confirm with the user (optional)

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -68,6 +68,10 @@ Fixes #45
 
 Rules:
 
+- Do NOT hard-wrap the PR body at 80 characters. GitHub reflows it as prose,
+  so write natural paragraphs (one line per paragraph) and let them wrap on
+  render. Repo Markdown files still wrap at 80 — this exception applies only to
+  text posted to GitHub (PR descriptions, issue bodies, comments).
 - Use `Fixes #N` (not "Closes" or "Resolves") if an issue number is available.
 - Mark the correct type with `[x]` (no spaces inside the brackets).
 - Skip "Screenshots" and "Additional Notes" sections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,9 +212,12 @@ daisy_button(color: :primary, size: :lg)
   keeps each entry readable. Indent continuation lines to align with the text
   after the list marker (2 spaces under a top-level `- `, 4 under a nested
   `  - `).
-- Exception: pull request descriptions are exempt from line wrapping — GitHub
-  renders them as flowing prose, so the 80-character limit does not apply. Write
-  natural paragraphs and let them wrap on render.
+- Exception: text that GitHub renders — pull request descriptions, issue
+  bodies, and PR / issue comments — is exempt from line wrapping. GitHub
+  reflows it as prose, so the 80-character limit does not apply; do NOT
+  hard-wrap it. Write natural paragraphs (one line each) and let them wrap on
+  render. This covers only content posted to GitHub — Markdown files in the
+  repo (`README`, `docs/`, `CLAUDE.md`, the skills) still wrap at 80.
 - Never split an inline code span (`` `...` ``), a Markdown link
   (`[text](url)`), or a `<code>` tag across lines. A line may exceed its limit
   only when one such unbreakable token is itself too long; prose must always


### PR DESCRIPTION
## Context

CLAUDE.md already exempted PR descriptions from the 80-character wrap, but the rule lived only in the general Markdown section — the `create-pr` and `create-issue` skills never restated it, so it was easy to hard-wrap a PR body out of habit (which is exactly what happened on #163 before it was fixed). This reinforces the rule at the point of use and broadens it to all GitHub-rendered text.

## Related Issues

None.

## Type of Change

- [x] Documentation update

## Description

- **CLAUDE.md** — broadened the line-wrap exception from "pull request descriptions" to all GitHub-rendered text (PR descriptions, issue bodies, and PR / issue comments), and made it explicit: do NOT hard-wrap it. Repo Markdown files (README, `docs/`, CLAUDE.md, the skills themselves) still wrap at 80.
- **create-pr skill** — added a Step 4 rule to write the PR body as flowing paragraphs rather than hard-wrapping at 80.
- **create-issue skill** — added the same guidance for issue bodies.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have followed the project's documentation standards

Remaining checklist items are not applicable — this is a docs-only change with no code or tests.

## Additional Notes

This PR description is itself written as flowing prose (no hard wraps), matching the rule it documents.
