### PR TITLE
feat(Modal): Add loco-modal Stimulus controller with open/close API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   built-in trigger button — so one modal can live in a layout and be opened from anywhere on the page (a
   link, another component, or JavaScript). Also lets a call-time `html: { tabindex: -1 }` on the activator
   override the default `tabindex="0"`, which the build-time default previously clobbered. Refs #161.
+- feat(Modal): Add an optional `loco-modal` Stimulus controller that opens and closes the `<dialog>` from
+  JavaScript (`loco-modal#open` / `loco-modal#close`) and dispatches bubbling `loco-modal:open` /
+  `loco-modal:close` lifecycle events. The controller re-dispatches the dialog's non-bubbling native `close`
+  event, so `loco-modal:close` fires for every close (Escape, backdrop, a `<form method="dialog">` submit, or
+  the `close` action). It is attached to every modal automatically but stays inert until an app registers it,
+  so existing modals are unaffected. Refs #161, #16.
 
 ### Demo / Docs Changes
 
@@ -82,6 +88,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   note and the `CLAUDE.md` version reference, and trimmed the README's duplicated install walkthrough to a
   quickstart that points at the Install guide as the canonical source (the `bundle show` gotcha moved into
   that guide).
+- docs(Install): Document registering the `loco-modal` controller in the install guide, and update the
+  Modals demo's "Global Modal" example to surface its `loco-modal:close` lifecycle event.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   quickstart that points at the Install guide as the canonical source (the `bundle show` gotcha moved into
   that guide).
 - docs(Install): Document registering the `loco-modal` controller in the install guide, and update the
-  Modals demo's "Global Modal" example to surface its `loco-modal:close` lifecycle event.
+  Modals demo's "Global Modal" example to close via the `loco-modal#close` action and surface its
+  `loco-modal:close` lifecycle event.
 
 ### Fixed
 

--- a/app/components/daisy/actions/modal_component.rb
+++ b/app/components/daisy/actions/modal_component.rb
@@ -83,8 +83,7 @@
 #   = daisy_modal(title: "Settings", trigger: false, dialog_id: "app-modal") do |modal|
 #     %p This modal has no built-in trigger — open it from anywhere.
 #     - modal.with_end_actions do
-#       %form{ method: :dialog }
-#         = daisy_button { "Close" }
+#       = daisy_button(action: "loco-modal#close") { "Close" }
 #
 #   = daisy_button(html: { onclick: "document.getElementById('app-modal').showModal()" }) { "Open" }
 #

--- a/app/components/daisy/actions/modal_component.rb
+++ b/app/components/daisy/actions/modal_component.rb
@@ -9,6 +9,15 @@
 # (`showModal()` and `close()`). This provides better accessibility and keyboard
 # navigation compared to div-based modals.
 #
+# @note Register the `loco-modal` Stimulus controller (see the Install guide)
+#   to drive the dialog from JavaScript. It is attached to the `<dialog>`
+#   automatically but stays inert until registered, so basic modals keep
+#   working without it. The controller adds `loco-modal#open` and
+#   `loco-modal#close` actions and dispatches bubbling `loco-modal:open` /
+#   `loco-modal:close` events. Because the native `<dialog>` `close` event does
+#   not bubble, `loco-modal:close` fires for every close — the Escape key, the
+#   backdrop, a `<form method="dialog">` submit, or the `close` action.
+#
 # @part box The container for the modal content, providing padding and layout.
 # @part close_icon_wrapper The container for the close icon, positioned in the
 #   top-right corner.
@@ -184,6 +193,10 @@ module Daisy
         set_tag_name(:component, :dialog)
         add_html(:component, id: dialog_id)
         add_css(:component, "modal")
+
+        # Attach the optional `loco-modal` Stimulus controller. It is inert
+        # until an app registers it, so modals keep working without any JS.
+        add_stimulus_controller(:component, "loco-modal")
       end
 
       def setup_backdrop

--- a/app/components/daisy/actions/modal_controller.js
+++ b/app/components/daisy/actions/modal_controller.js
@@ -1,0 +1,78 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Modal Controller
+ *
+ * A Stimulus controller that opens and closes a native `<dialog>` modal and
+ * emits lifecycle events. LocoMotion attaches it to the `<dialog>` element
+ * automatically (via `data-controller="loco-modal"`), so `this.element` is the
+ * dialog itself.
+ *
+ * Register it as `loco-modal` (see the Install guide) to enable the API. It is
+ * inert until registered, so modals keep working without it.
+ *
+ * Actions:
+ *
+ *   - `loco-modal#open`  — shows the dialog and dispatches `loco-modal:open`.
+ *   - `loco-modal#close` — closes the dialog, which dispatches
+ *     `loco-modal:close`.
+ *
+ * Events (both bubble, so you can listen for them on any ancestor):
+ *
+ *   - `loco-modal:open`  — dispatched after the dialog is shown.
+ *   - `loco-modal:close` — dispatched after the dialog is closed by ANY means
+ *     (the Escape key, the backdrop, a `<form method="dialog">` submit, or the
+ *     `close` action). The native `<dialog>` `close` event does not bubble, so
+ *     the controller re-dispatches a bubbling `loco-modal:close` in its place.
+ */
+export default class extends Controller {
+  /**
+   * Binds the dialog's native `close` event so every close — however it is
+   * triggered — emits a bubbling `loco-modal:close`.
+   *
+   * @returns {void}
+   */
+  connect() {
+    this.boundDispatchClose = this.dispatchClose.bind(this)
+    this.element.addEventListener("close", this.boundDispatchClose)
+  }
+
+  /**
+   * Removes the native `close` listener to avoid leaking it across reconnects.
+   *
+   * @returns {void}
+   */
+  disconnect() {
+    this.element.removeEventListener("close", this.boundDispatchClose)
+  }
+
+  /**
+   * Opens the modal and announces it with a `loco-modal:open` event.
+   *
+   * @returns {void}
+   */
+  open() {
+    this.element.showModal()
+    this.dispatch("open")
+  }
+
+  /**
+   * Closes the modal. The resulting native `close` event triggers
+   * `loco-modal:close` via {@link dispatchClose}.
+   *
+   * @returns {void}
+   */
+  close() {
+    this.element.close()
+  }
+
+  /**
+   * Re-dispatches the dialog's non-bubbling native `close` event as a bubbling
+   * `loco-modal:close` so ancestors and document-level listeners can react.
+   *
+   * @returns {void}
+   */
+  dispatchClose() {
+    this.dispatch("close")
+  }
+}

--- a/docs/demo/app/javascript/controllers/index.js
+++ b/docs/demo/app/javascript/controllers/index.js
@@ -6,10 +6,11 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Import LocoMotion controllers
-import { AlertController, CallyInputController, CountdownController, ThemeController } from "@profoundry-us/loco_motion"
+import { AlertController, CallyInputController, CountdownController, ModalController, ThemeController } from "@profoundry-us/loco_motion"
 application.register("loco-alert", AlertController)
 application.register("loco-cally-input", CallyInputController)
 application.register("loco-countdown", CountdownController)
+application.register("loco-modal", ModalController)
 application.register("loco-theme", ThemeController)
 
 // Import demo app controllers

--- a/docs/demo/app/views/docs/02_install.html.haml
+++ b/docs/demo/app/views/docs/02_install.html.haml
@@ -68,11 +68,17 @@
       const application = Application.start()
 
       // Import LocoMotion controllers
-      import { CountdownController, ThemeController, CallyInputController } from "@profoundry-us/loco_motion"
+      import { CountdownController, ThemeController, CallyInputController, ModalController } from "@profoundry-us/loco_motion"
 
       application.register("loco-countdown", CountdownController)
       application.register("loco-theme", ThemeController)
       application.register("loco-cally-input", CallyInputController)
+      application.register("loco-modal", ModalController)
+
+  .prose.mt-4
+    :markdown
+      The `loco-modal` controller is only required for the Modal's programmatic
+      open/close API and Global Modal features — basic modals work without it.
 
 .max-w-prose
   = doc_note(css: "mt-6", modifier: :warning, title: "Cally Javascript Setup") do

--- a/docs/demo/app/views/examples/daisy/actions/modals.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/modals.html.haml
@@ -101,9 +101,11 @@
         navbar, a table row, or anywhere else.
 
         - modal.with_end_actions(css: "flex flex-row items-center gap-2") do
-          %form{ method: :dialog }
-            = daisy_button(css: "btn-primary") do
-              Close
+          -# `action:` attaches a Stimulus action — Stimulus infers the button's
+          -# `click`, so this in-dialog button drives the controller's `close`
+          -# action directly, with no wrapper `<form method="dialog">` needed.
+          = daisy_button(css: "btn-primary", action: "loco-modal#close") do
+            Close
 
 :javascript
   // Demo only: surface the modal's lifecycle event. The loco-modal controller

--- a/docs/demo/app/views/examples/daisy/actions/modals.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/modals.html.haml
@@ -73,14 +73,27 @@
         built-in button**. Drop a single modal in your layout and open it from
         anywhere on the page — a link, another component, or JavaScript.
 
+        Register the `loco-modal` Stimulus controller (see the Install guide)
+        and the dialog gains `loco-modal#open` / `loco-modal#close` actions plus
+        bubbling `loco-modal:open` / `loco-modal:close` events. Because the
+        controller re-dispatches the native `<dialog>` `close` event,
+        `loco-modal:close` fires no matter how the modal closes — the status
+        line below updates whether you use the **Close** button, the backdrop,
+        or the Escape key.
+
       = doc_note(css: "mb-8") do
-        Until the `loco-modal` Stimulus controller lands, open it however you
-        like. Here we use a small inline `onclick` for demonstration; a later
-        PR will replace this with a Stimulus action.
+        :markdown
+          The opener below is a one-line `onclick`, because a *distant* trigger
+          can't reach the dialog's controller through a Stimulus action. A
+          follow-up Turbo Frame example will open the same modal with no custom
+          JavaScript.
 
     .flex.flex-col.items-center.gap-4
       = daisy_button(css: "btn-primary", html: { onclick: "document.getElementById('global-demo').showModal()" }) do
         Open Global Modal
+
+      %p.text-sm.opacity-70{ data: { global_modal_status: true } }
+        Close the modal to see its loco-modal:close event.
 
       = daisy_modal(title: "Global Modal", trigger: false, dialog_id: "global-demo") do |modal|
         This modal has no built-in trigger. It was opened by a separate button
@@ -91,3 +104,16 @@
           %form{ method: :dialog }
             = daisy_button(css: "btn-primary") do
               Close
+
+:javascript
+  // Demo only: surface the modal's lifecycle event. The loco-modal controller
+  // re-dispatches the dialog's native `close` as a bubbling `loco-modal:close`,
+  // so a single document-level listener catches every close.
+  document.addEventListener("loco-modal:close", (event) => {
+    if (event.target.id !== "global-demo") return
+
+    const status = document.querySelector("[data-global-modal-status]")
+    if (status) {
+      status.textContent = "loco-modal:close fired — the dialog closed."
+    }
+  })

--- a/docs/demo/e2e/daisy/actions/modals.spec.ts
+++ b/docs/demo/e2e/daisy/actions/modals.spec.ts
@@ -128,7 +128,8 @@ test.describe('global modal controller', () => {
     await expect(modal).toBeVisible();
 
     // Close through the dialog's own Close button (a native dialog-method form).
-    await modal.getByRole('button', { name: 'Close' }).click();
+    // Scope to the box so we don't match the dialog's "close" backdrop button.
+    await modal.locator('.modal-box').getByRole('button', { name: 'Close', exact: true }).click();
     await expect(modal).toBeHidden();
 
     // The controller turned the non-bubbling native `close` into a bubbling

--- a/docs/demo/e2e/daisy/actions/modals.spec.ts
+++ b/docs/demo/e2e/daisy/actions/modals.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, Locator } from '@playwright/test';
+import { expect, test, Locator, Page } from '@playwright/test';
 import { loco } from '../../spec_helpers';
 
 /**
@@ -14,7 +14,8 @@ test('page loads', async ({ page }) => {
   await loco.expectPageTitle(page, /Modals | LocoMotion/);
   await loco.expectPageHeadings(page, [
     'Simple Modal',
-    'Custom Activator'
+    'Custom Activator',
+    'Global Modal'
   ]);
 });
 
@@ -71,3 +72,67 @@ test.describe('simple modal', () => {
   })
 
 })
+
+/**
+ * Invoke the global modal's `loco-modal` Stimulus controller once it has
+ * connected, so tests can open/close it programmatically.
+ */
+async function callController(page: Page, method: 'open' | 'close') {
+  await page.waitForFunction(() => {
+    const dialog = document.getElementById('global-demo');
+    return !!(dialog && (window as any).Stimulus
+      && (window as any).Stimulus.getControllerForElementAndIdentifier(dialog, 'loco-modal'));
+  });
+
+  await page.evaluate((m) => {
+    const dialog = document.getElementById('global-demo');
+    (window as any).Stimulus
+      .getControllerForElementAndIdentifier(dialog, 'loco-modal')[m]();
+  }, method);
+}
+
+/**
+ * Test suite for the Global Modal (`trigger: false`) and its `loco-modal`
+ * controller: the programmatic open/close API and the bubbling
+ * `loco-modal:close` lifecycle event.
+ */
+test.describe('global modal controller', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/examples/Daisy::Actions::ModalComponent');
+  });
+
+  test('opens programmatically through the controller', async ({ page }) => {
+    const modal = page.locator('#global-demo');
+    await expect(modal).toBeHidden();
+
+    await callController(page, 'open');
+
+    await expect(modal).toBeVisible();
+  });
+
+  test('closes programmatically through the controller', async ({ page }) => {
+    const modal = page.locator('#global-demo');
+
+    await page.click('button:has-text("Open Global Modal")');
+    await expect(modal).toBeVisible();
+
+    await callController(page, 'close');
+
+    await expect(modal).toBeHidden();
+  });
+
+  test('re-dispatches a bubbling loco-modal:close on close', async ({ page }) => {
+    const modal = page.locator('#global-demo');
+
+    await page.click('button:has-text("Open Global Modal")');
+    await expect(modal).toBeVisible();
+
+    // Close through the dialog's own Close button (a native dialog-method form).
+    await modal.getByRole('button', { name: 'Close' }).click();
+    await expect(modal).toBeHidden();
+
+    // The controller turned the non-bubbling native `close` into a bubbling
+    // `loco-modal:close`, which the demo's document-level listener caught.
+    await expect(page.getByText('loco-modal:close fired', { exact: false })).toBeVisible();
+  });
+});

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 import AlertController from './app/components/daisy/feedback/alert_controller';
 import CallyInputController from './app/components/daisy/data_input/cally_input_controller';
 import CountdownController from './app/components/daisy/data_display/countdown_controller';
+import ModalController from './app/components/daisy/actions/modal_controller';
 import ThemeController from './app/components/daisy/actions/theme_controller';
 
 export {
   AlertController,
   CallyInputController,
   CountdownController,
+  ModalController,
   ThemeController,
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "app/components/daisy/feedback/alert_controller.js",
     "app/components/daisy/data_input/cally_input_controller.js",
     "app/components/daisy/data_display/countdown_controller.js",
+    "app/components/daisy/actions/modal_controller.js",
     "app/components/daisy/actions/theme_controller.js"
   ]
 }


### PR DESCRIPTION
## Context

This is the second of three dependency-ordered PRs implementing the Global Modal and programmatic-open work for the Modal component. PR A (#163, merged) added the `trigger: false` Global Modal render. This PR layers a clean JavaScript API on top of it — a `loco-modal` Stimulus controller with `open`/`close` actions and lifecycle events — which also gives issue #16 ("Modal should use a Stimulus controller") its controller. A later Turbo Frame PR will finish the series.

## Related Issues

Refs #161, #16.

This PR intentionally does **not** finish either issue. A later Turbo Frame PR will wrap up the epic with a `Fixes` reference there, and the `wontfix` label on #16 should be revisited once this lands. The core controller is delivered here; fully migrating the default button off its inline `onclick` is deferred to a future minor, since that change is breaking.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

A new `loco-modal` Stimulus controller is attached to every modal's `<dialog>` element. It exposes `loco-modal#open` and `loco-modal#close` actions and dispatches bubbling `loco-modal:open` and `loco-modal:close` lifecycle events. Because the native `<dialog>` `close` event does not bubble, the controller binds it directly and re-dispatches a bubbling `loco-modal:close` — so a single ancestor or document-level listener catches every close, whether it came from the Escape key, the backdrop, a `<form method="dialog">` submit, or the `close` action.

The controller is additive and inert. It is attached automatically via the existing `add_stimulus_controller` helper but does nothing until an app registers it, so existing modals keep working with no JavaScript changes. The default modal button also keeps its inline `onclick`, which keeps this PR fully backward compatible.

On the wiring side, the package barrel (`index.js`) now exports `ModalController` and `package.json` ships the new controller file. The demo registers `loco-modal` in its `controllers/index.js`, and the Install guide documents the registration with a note that it is only needed for the Modal's programmatic / Global Modal features. The demo's "Global Modal" example now surfaces the bubbling `loco-modal:close` event in a small status line, and new Playwright specs cover programmatic `open()` / `close()` and the re-dispatched close event.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

One deliberate call on the demo: the "Open" button still uses a one-line inline `onclick`. A *distant* trigger — which is the entire point of a Global Modal, e.g. a navbar or a table row — cannot reach the dialog's controller through a Stimulus `data-action`, because Stimulus resolves actions by DOM ancestry and the trigger is not inside the `<dialog>`. The no-JavaScript "open from anywhere" story arrives with the later Turbo Frame integration, where the frame lives inside the dialog and the idiomatic `turbo:frame-load->loco-modal#open` wiring is in scope.

Verification: library RSpec 1200 examples / 0 failures, demo RSpec 72 / 0, modal Playwright e2e 7/7 on chromium, RuboCop clean on the changed Ruby, and the Install page renders with the new registration snippet.
