### PR TITLE
docs(Button): Document the action parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   note and the `CLAUDE.md` version reference, and trimmed the README's duplicated install walkthrough to a
   quickstart that points at the Install guide as the canonical source (the `bundle show` gotcha moved into
   that guide).
+- docs(Button): Document `ButtonComponent`'s `action:` parameter, which attaches a Stimulus action via the
+  button's `data-action` attribute. Added the missing `@option action` entry to the `initialize` YARD (noting
+  that Stimulus infers the `click` event for buttons, so `action: "my-controller#handle"` is shorthand for
+  `action: "click->my-controller#handle"`) plus a "Stimulus Action" `@loco_example`. The parameter already
+  worked and was spec-covered, but was previously undocumented.
 
 ### Fixed
 

--- a/app/components/daisy/actions/button_component.rb
+++ b/app/components/daisy/actions/button_component.rb
@@ -28,6 +28,10 @@
 #     = daisy_button do
 #       Button 2
 #
+# @loco_example Stimulus Action
+#   %div{ data: { controller: "greeter" } }
+#     = daisy_button("Say Hello", action: "greeter#greet")
+#
 # @loco_example Default Button
 #   = daisy_button { "Default Button" }
 #
@@ -127,6 +131,11 @@ module Daisy
       #
       # @option kws target          [String] The HTML `target` of for the `<a>` tag
       #   (`_blank`, `_parent`, or a specific tab / window / iframe, etc).
+      #
+      # @option kws action          [String] A Stimulus action wired to the
+      #   button via its `data-action` attribute. Stimulus infers the `click`
+      #   event for buttons, so `action: "my-controller#handle"` works as a
+      #   shorthand for `action: "click->my-controller#handle"`.
       #
       # @option kws icon            [String] The name of Hero icon to render inside
       #   the button.  This is an alias of `left_icon`.


### PR DESCRIPTION
## Context

`Daisy::Actions::ButtonComponent` accepts an `action:` parameter (the 2nd positional arg, or a keyword) that renders a Stimulus `data-action` attribute on the button — e.g. `daisy_button(action: "click->my-controller#handle")` renders `<button data-action="click->my-controller#handle">`. The behavior is fully implemented (via `setup_component`) and spec-covered (the "with Stimulus action" and "with both title and action parameters" contexts), but it was undocumented: missing from the `@option kws` list in the `initialize` YARD, with no `@loco_example` demonstrating it. That makes a genuinely useful parameter undiscoverable — the Global Modal demo (#166) relies on `daisy_button(action: "loco-modal#close")`, for instance.

## Related Issues

None — documentation-only follow-up.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Added the missing `@option kws action [String]` entry to <code>app/components/daisy/actions/button_component.rb</code>'s `initialize` YARD, following the existing aligned, blank-line-between-entries style. It notes that the parameter attaches a Stimulus action via the `data-action` attribute, and that Stimulus infers the `click` event for buttons — so the shorthand `action: "my-controller#handle"` works as well as the explicit `action: "click->my-controller#handle"`.
- Added a "Stimulus Action" `@loco_example` showing a button wired to a small `greeter` controller via `action:`.
- Recorded the change in <code>CHANGELOG.md</code> under "Demo / Docs Changes".

No behavior change — this is documentation only. The parameter and its specs already existed.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qWdgcbx17RiBXG136Skme

---
_Generated by [Claude Code](https://claude.ai/code/session_016qWdgcbx17RiBXG136Skme)_