### PR TITLE
feat(Modal): Add turbo_frame: option for the Global Modal pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   event, so `loco-modal:close` fires for every close (Escape, backdrop, a `<form method="dialog">` submit, or
   the `close` action). It is attached to every modal automatically but stays inert until an app registers it,
   so existing modals are unaffected. Refs #161, #16.
+- feat(Modal): Add a `turbo_frame:` option that renders an empty `<turbo-frame>` inside the modal and wires
+  the `loco-modal` controller to open the dialog when that frame loads (and clear it on close). Combined with
+  `trigger: false` this delivers the canonical Hotwire "Global Modal" pattern: one modal in your layout,
+  opened by pointing `data-turbo-frame` links at the frame id — no per-row modals or inline JavaScript.
+  Refs #161, #16.
 
 ### Demo / Docs Changes
 
@@ -96,6 +101,9 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - docs(Install): Document registering the `loco-modal` controller in the install guide, and update the
   Modals demo's "Global Modal" example to close via the `loco-modal#close` action and surface its
   `loco-modal:close` lifecycle event.
+- docs(Modal): Add a "Global Modal (Turbo Frame)" demo example — a contact list whose edit links stream an
+  edit form into one shared modal via a `<turbo-frame>` — backed by a small demo-only `ModalContacts`
+  controller, plus a Turbo Frame `@loco_example` and `@option turbo_frame` in the component's YARD.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   event, so `loco-modal:close` fires for every close (Escape, backdrop, a `<form method="dialog">` submit, or
   the `close` action). It is attached to every modal automatically but stays inert until an app registers it,
   so existing modals are unaffected. Refs #161, #16.
-- feat(Modal): Add a `turbo_frame:` option that renders an empty `<turbo-frame>` inside the modal and wires
+- feat(Modal): Add a `turbo_frame_id:` option that renders an empty `<turbo-frame>` inside the modal and wires
   the `loco-modal` controller to open the dialog when that frame loads (and clear it on close). Combined with
   `trigger: false` this delivers the canonical Hotwire "Global Modal" pattern: one modal in your layout,
   opened by pointing `data-turbo-frame` links at the frame id — no per-row modals or inline JavaScript.
@@ -103,7 +103,7 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `loco-modal:close` lifecycle event.
 - docs(Modal): Add a "Global Modal (Turbo Frame)" demo example — a contact list whose edit links stream an
   edit form into one shared modal via a `<turbo-frame>` — backed by a small demo-only `ModalContacts`
-  controller, plus a Turbo Frame `@loco_example` and `@option turbo_frame` in the component's YARD.
+  controller, plus a Turbo Frame `@loco_example` and `@option turbo_frame_id` in the component's YARD.
 
 ### Fixed
 

--- a/app/components/daisy/actions/modal_component.html.haml
+++ b/app/components/daisy/actions/modal_component.html.haml
@@ -19,7 +19,7 @@
       = part(:title) do
         = @simple_title
 
-    - if turbo_frame?
+    - if @simple_turbo_frame.present?
       = part(:turbo_frame) do
         = content
     - else

--- a/app/components/daisy/actions/modal_component.html.haml
+++ b/app/components/daisy/actions/modal_component.html.haml
@@ -19,7 +19,11 @@
       = part(:title) do
         = @simple_title
 
-    = content
+    - if turbo_frame?
+      = part(:turbo_frame) do
+        = content
+    - else
+      = content
 
     - if start_actions? || end_actions?
       = part(:actions) do

--- a/app/components/daisy/actions/modal_component.html.haml
+++ b/app/components/daisy/actions/modal_component.html.haml
@@ -19,7 +19,7 @@
       = part(:title) do
         = @simple_title
 
-    - if @simple_turbo_frame.present?
+    - if @turbo_frame_id.present?
       = part(:turbo_frame) do
         = content
     - else

--- a/app/components/daisy/actions/modal_component.rb
+++ b/app/components/daisy/actions/modal_component.rb
@@ -87,13 +87,21 @@
 #
 #   = daisy_button(html: { onclick: "document.getElementById('app-modal').showModal()" }) { "Open" }
 #
+# @loco_example Global Modal with a Turbo Frame
+#   -# One shared modal; each link streams its content into the frame, which
+#   -# opens the dialog on load. No per-row modals, no inline JavaScript.
+#   = daisy_modal(trigger: false, turbo_frame: "contact", dialog_id: "contact-modal")
+#
+#   = link_to "Edit Contact", edit_contact_path(1), data: { turbo_frame: "contact" }
+#
 module Daisy
   module Actions
     class ModalComponent < LocoMotion::BaseComponent
       set_component_name :modal
 
       define_parts :box, :actions, :close_icon_wrapper, :close_icon,
-                   :backdrop, :title, :start_actions, :end_actions
+                   :backdrop, :title, :start_actions, :end_actions,
+                   :turbo_frame
 
       renders_one :activator, LocoMotion::BasicComponent
       renders_one :button, Daisy::Actions::ButtonComponent
@@ -110,6 +118,15 @@ module Daisy
       #   false, only the `<dialog>` is rendered (a "Global Modal").
       attr_reader :trigger
       alias trigger? trigger
+
+      # @return [String, nil] The id of the `<turbo-frame>` rendered inside the
+      #   modal for the Turbo Frame "Global Modal" pattern, or nil when unused.
+      attr_reader :turbo_frame
+
+      # @return [Boolean] Whether a `turbo_frame:` id was supplied.
+      def turbo_frame?
+        @turbo_frame.present?
+      end
 
       # @return [String] The unique ID for the `<dialog>` element.
       attr_reader :dialog_id
@@ -141,12 +158,20 @@ module Daisy
       #   with no built-in trigger — a "Global Modal" that you place once and
       #   open from elsewhere (a link, another component, or JavaScript).
       #
+      # @option kws turbo_frame [String] Renders an empty `<turbo-frame>` with
+      #   this id inside the modal and wires the `loco-modal` controller to open
+      #   the dialog when that frame loads (and clear it on close). Combine with
+      #   `trigger: false` for the Hotwire "Global Modal" pattern: place one
+      #   modal in your layout and point `data-turbo-frame` links at this id to
+      #   stream remote content into it. Requires the registered controller.
+      #
       def initialize(title = nil, **kws, &block)
         super
 
         @dialog_id = config_option(:dialog_id, SecureRandom.uuid)
         @closable = config_option(:closable, true)
         @trigger = config_option(:trigger, true)
+        @turbo_frame = config_option(:turbo_frame, nil)
         @simple_title = config_option(:title, title)
       end
 
@@ -158,6 +183,7 @@ module Daisy
         setup_component
         setup_backdrop
         setup_box
+        setup_turbo_frame
         setup_close_icon
         setup_title
         setup_actions
@@ -206,6 +232,18 @@ module Daisy
 
       def setup_box
         add_css(:box, "modal-box relative")
+      end
+
+      def setup_turbo_frame
+        return unless turbo_frame?
+
+        set_tag_name(:turbo_frame, "turbo-frame")
+        add_html(:turbo_frame, id: @turbo_frame)
+
+        # Hand the frame id to the `loco-modal` controller (as its `turboFrame`
+        # value) so it can open the dialog on `turbo:frame-load` and clear the
+        # frame on close.
+        add_data(:component, "loco-modal-turbo-frame-value": @turbo_frame)
       end
 
       def setup_close_icon

--- a/app/components/daisy/actions/modal_component.rb
+++ b/app/components/daisy/actions/modal_component.rb
@@ -90,7 +90,7 @@
 # @loco_example Global Modal with a Turbo Frame
 #   -# One shared modal; each link streams its content into the frame, which
 #   -# opens the dialog on load. No per-row modals, no inline JavaScript.
-#   = daisy_modal(trigger: false, turbo_frame: "contact", dialog_id: "contact-modal")
+#   = daisy_modal(trigger: false, turbo_frame_id: "contact", dialog_id: "contact-modal")
 #
 #   = link_to "Edit Contact", edit_contact_path(1), data: { turbo_frame: "contact" }
 #
@@ -119,11 +119,9 @@ module Daisy
       attr_reader :trigger
       alias trigger? trigger
 
-      # @return [String, nil] Accessor for the `turbo_frame` id passed via the
-      #   component config. Stored under a `simple_` prefix (like
-      #   {#simple_title}) so the option does not collide with the `:turbo_frame`
-      #   part it configures. Nil when unused.
-      attr_reader :simple_turbo_frame
+      # @return [String, nil] The id for the `<turbo-frame>` rendered inside the
+      #   modal (the Turbo Frame "Global Modal" pattern), or nil when unused.
+      attr_reader :turbo_frame_id
 
       # @return [String] The unique ID for the `<dialog>` element.
       attr_reader :dialog_id
@@ -155,7 +153,7 @@ module Daisy
       #   with no built-in trigger — a "Global Modal" that you place once and
       #   open from elsewhere (a link, another component, or JavaScript).
       #
-      # @option kws turbo_frame [String] Renders an empty `<turbo-frame>` with
+      # @option kws turbo_frame_id [String] Renders an empty `<turbo-frame>` with
       #   this id inside the modal and wires the `loco-modal` controller to open
       #   the dialog when that frame loads (and clear it on close). Combine with
       #   `trigger: false` for the Hotwire "Global Modal" pattern: place one
@@ -168,7 +166,7 @@ module Daisy
         @dialog_id = config_option(:dialog_id, SecureRandom.uuid)
         @closable = config_option(:closable, true)
         @trigger = config_option(:trigger, true)
-        @simple_turbo_frame = config_option(:turbo_frame, nil)
+        @turbo_frame_id = config_option(:turbo_frame_id, nil)
         @simple_title = config_option(:title, title)
       end
 
@@ -232,15 +230,15 @@ module Daisy
       end
 
       def setup_turbo_frame
-        return unless @simple_turbo_frame.present?
+        return unless @turbo_frame_id.present?
 
         set_tag_name(:turbo_frame, "turbo-frame")
-        add_html(:turbo_frame, id: @simple_turbo_frame)
+        add_html(:turbo_frame, id: @turbo_frame_id)
 
-        # Hand the frame id to the `loco-modal` controller (as its `turboFrame`
+        # Hand the frame id to the `loco-modal` controller (as its `turboFrameId`
         # value) so it can open the dialog on `turbo:frame-load` and clear the
         # frame on close.
-        add_data(:component, "loco-modal-turbo-frame-value": @simple_turbo_frame)
+        add_data(:component, "loco-modal-turbo-frame-id-value": @turbo_frame_id)
       end
 
       def setup_close_icon

--- a/app/components/daisy/actions/modal_component.rb
+++ b/app/components/daisy/actions/modal_component.rb
@@ -119,14 +119,11 @@ module Daisy
       attr_reader :trigger
       alias trigger? trigger
 
-      # @return [String, nil] The id of the `<turbo-frame>` rendered inside the
-      #   modal for the Turbo Frame "Global Modal" pattern, or nil when unused.
-      attr_reader :turbo_frame
-
-      # @return [Boolean] Whether a `turbo_frame:` id was supplied.
-      def turbo_frame?
-        @turbo_frame.present?
-      end
+      # @return [String, nil] Accessor for the `turbo_frame` id passed via the
+      #   component config. Stored under a `simple_` prefix (like
+      #   {#simple_title}) so the option does not collide with the `:turbo_frame`
+      #   part it configures. Nil when unused.
+      attr_reader :simple_turbo_frame
 
       # @return [String] The unique ID for the `<dialog>` element.
       attr_reader :dialog_id
@@ -171,7 +168,7 @@ module Daisy
         @dialog_id = config_option(:dialog_id, SecureRandom.uuid)
         @closable = config_option(:closable, true)
         @trigger = config_option(:trigger, true)
-        @turbo_frame = config_option(:turbo_frame, nil)
+        @simple_turbo_frame = config_option(:turbo_frame, nil)
         @simple_title = config_option(:title, title)
       end
 
@@ -235,15 +232,15 @@ module Daisy
       end
 
       def setup_turbo_frame
-        return unless turbo_frame?
+        return unless @simple_turbo_frame.present?
 
         set_tag_name(:turbo_frame, "turbo-frame")
-        add_html(:turbo_frame, id: @turbo_frame)
+        add_html(:turbo_frame, id: @simple_turbo_frame)
 
         # Hand the frame id to the `loco-modal` controller (as its `turboFrame`
         # value) so it can open the dialog on `turbo:frame-load` and clear the
         # frame on close.
-        add_data(:component, "loco-modal-turbo-frame-value": @turbo_frame)
+        add_data(:component, "loco-modal-turbo-frame-value": @simple_turbo_frame)
       end
 
       def setup_close_icon

--- a/app/components/daisy/actions/modal_controller.js
+++ b/app/components/daisy/actions/modal_controller.js
@@ -25,13 +25,13 @@ import { Controller } from "@hotwired/stimulus"
  *     `close` action). The native `<dialog>` `close` event does not bubble, so
  *     the controller re-dispatches a bubbling `loco-modal:close` in its place.
  *
- * Turbo Frame (Global Modal): set the `turboFrame` value
- * (`data-loco-modal-turbo-frame-value`) to a `<turbo-frame>` id and the
+ * Turbo Frame (Global Modal): set the `turboFrameId` value
+ * (`data-loco-modal-turbo-frame-id-value`) to a `<turbo-frame>` id and the
  * controller opens the dialog when that frame finishes loading and clears it on
  * close — the canonical Hotwire pattern for one shared, lazily-filled modal.
  */
 export default class extends Controller {
-  static values = { turboFrame: String }
+  static values = { turboFrameId: String }
 
   /**
    * Binds the dialog's native `close` event so every close — however it is
@@ -102,9 +102,9 @@ export default class extends Controller {
    * @returns {void}
    */
   connectTurboFrame() {
-    if (!this.hasTurboFrameValue) return
+    if (!this.hasTurboFrameIdValue) return
 
-    this.frame = document.getElementById(this.turboFrameValue)
+    this.frame = document.getElementById(this.turboFrameIdValue)
     if (!this.frame) return
 
     this.boundOpen = this.open.bind(this)

--- a/app/components/daisy/actions/modal_controller.js
+++ b/app/components/daisy/actions/modal_controller.js
@@ -24,34 +24,51 @@ import { Controller } from "@hotwired/stimulus"
  *     (the Escape key, the backdrop, a `<form method="dialog">` submit, or the
  *     `close` action). The native `<dialog>` `close` event does not bubble, so
  *     the controller re-dispatches a bubbling `loco-modal:close` in its place.
+ *
+ * Turbo Frame (Global Modal): set the `turboFrame` value
+ * (`data-loco-modal-turbo-frame-value`) to a `<turbo-frame>` id and the
+ * controller opens the dialog when that frame finishes loading and clears it on
+ * close — the canonical Hotwire pattern for one shared, lazily-filled modal.
  */
 export default class extends Controller {
+  static values = { turboFrame: String }
+
   /**
    * Binds the dialog's native `close` event so every close — however it is
-   * triggered — emits a bubbling `loco-modal:close`.
+   * triggered — emits a bubbling `loco-modal:close`, and (when a `turboFrame`
+   * value is set) wires the Turbo Frame auto-open / clear-on-close behavior.
    *
    * @returns {void}
    */
   connect() {
     this.boundDispatchClose = this.dispatchClose.bind(this)
     this.element.addEventListener("close", this.boundDispatchClose)
+
+    this.connectTurboFrame()
   }
 
   /**
-   * Removes the native `close` listener to avoid leaking it across reconnects.
+   * Removes the native `close` listener (and any Turbo Frame listeners) to
+   * avoid leaking them across reconnects.
    *
    * @returns {void}
    */
   disconnect() {
     this.element.removeEventListener("close", this.boundDispatchClose)
+
+    this.disconnectTurboFrame()
   }
 
   /**
-   * Opens the modal and announces it with a `loco-modal:open` event.
+   * Opens the modal and announces it with a `loco-modal:open` event. A no-op if
+   * the dialog is already open, so repeated `turbo:frame-load` events (e.g. a
+   * form submit replacing the frame) never re-call `showModal()` or re-dispatch.
    *
    * @returns {void}
    */
   open() {
+    if (this.element.open) return
+
     this.element.showModal()
     this.dispatch("open")
   }
@@ -74,5 +91,51 @@ export default class extends Controller {
    */
   dispatchClose() {
     this.dispatch("close")
+  }
+
+  /**
+   * Global Modal + Turbo Frame wiring. When a `turboFrame` value is set, opens
+   * the dialog as soon as that frame finishes loading remote content and
+   * empties the frame on close so reopening refetches instead of flashing the
+   * previous load. Inert (and harmless) when no frame is configured or found.
+   *
+   * @returns {void}
+   */
+  connectTurboFrame() {
+    if (!this.hasTurboFrameValue) return
+
+    this.frame = document.getElementById(this.turboFrameValue)
+    if (!this.frame) return
+
+    this.boundOpen = this.open.bind(this)
+    this.boundClearFrame = this.clearFrame.bind(this)
+    this.frame.addEventListener("turbo:frame-load", this.boundOpen)
+    this.element.addEventListener("close", this.boundClearFrame)
+  }
+
+  /**
+   * Removes the Turbo Frame listeners added in {@link connectTurboFrame}.
+   *
+   * @returns {void}
+   */
+  disconnectTurboFrame() {
+    if (!this.frame) return
+
+    this.frame.removeEventListener("turbo:frame-load", this.boundOpen)
+    this.element.removeEventListener("close", this.boundClearFrame)
+  }
+
+  /**
+   * Empties the configured Turbo Frame so the next visit refetches fresh
+   * content instead of showing the previous load.
+   *
+   * @returns {void}
+   */
+  clearFrame() {
+    if (!this.frame) return
+
+    this.frame.removeAttribute("complete")
+    this.frame.removeAttribute("src")
+    this.frame.innerHTML = ""
   }
 }

--- a/docs/demo/app/controllers/modal_contacts_controller.rb
+++ b/docs/demo/app/controllers/modal_contacts_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Demo-only controller backing the Modal "Global Modal (Turbo Frame)" example.
+#
+# `edit` streams an edit form into the modal's `<turbo-frame>` (the
+# `loco-modal` controller opens the dialog when the frame loads). `update`
+# pretends to save and returns `204 No Content` so Turbo fires `turbo:submit-end`
+# — which the form is wired to close on — without replacing the frame.
+class ModalContactsController < ApplicationController
+  CONTACTS = {
+    "1" => "Alice Anderson",
+    "2" => "Ben Brooks",
+    "3" => "Cara Castillo"
+  }.freeze
+
+  def edit
+    @id = params[:id]
+    @name = CONTACTS.fetch(@id, "Unknown Contact")
+
+    render layout: false
+  end
+
+  def update
+    head :no_content
+  end
+end

--- a/docs/demo/app/views/examples/daisy/actions/modals.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/modals.html.haml
@@ -125,7 +125,7 @@
           %li
             = link_to "Edit Contact #{id}", edit_modal_contact_path(id), data: { turbo_frame: "contact-modal" }
 
-      = daisy_modal(trigger: false, turbo_frame: "contact-modal", dialog_id: "contact-modal-dialog")
+      = daisy_modal(trigger: false, turbo_frame_id: "contact-modal", dialog_id: "contact-modal-dialog")
 
 :javascript
   // Demo only: surface the modal's lifecycle event. The loco-modal controller

--- a/docs/demo/app/views/examples/daisy/actions/modals.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/modals.html.haml
@@ -107,6 +107,26 @@
           = daisy_button(css: "btn-primary", action: "loco-modal#close") do
             Close
 
+%turbo-frame#global-turbo-frame-modal
+  = doc_example(title: "Global Modal (Turbo Frame)") do |doc|
+    - doc.with_description do
+      :markdown
+        The canonical Hotwire pattern: one Global Modal in your layout, filled on
+        demand by a `<turbo-frame>`. Pass a `turbo_frame:` id (with
+        `trigger: false`) and the modal renders an empty frame and wires the
+        `loco-modal` controller to **open the dialog when the frame loads** and
+        clear it on close. Each link below carries `data-turbo-frame`, so its
+        remote content streams into the same shared modal and pops it open — no
+        per-row modals and no inline JavaScript.
+
+    .flex.flex-col.items-center.gap-4
+      %ul.menu.bg-base-200.rounded-box.w-72
+        - %w[1 2 3].each do |id|
+          %li
+            = link_to "Edit Contact #{id}", edit_modal_contact_path(id), data: { turbo_frame: "contact-modal" }
+
+      = daisy_modal(trigger: false, turbo_frame: "contact-modal", dialog_id: "contact-modal-dialog")
+
 :javascript
   // Demo only: surface the modal's lifecycle event. The loco-modal controller
   // re-dispatches the dialog's native `close` as a bubbling `loco-modal:close`,

--- a/docs/demo/app/views/modal_contacts/edit.html.haml
+++ b/docs/demo/app/views/modal_contacts/edit.html.haml
@@ -1,0 +1,12 @@
+%turbo-frame#contact-modal
+  %h4.text-xl.font-bold.mb-4= "Edit #{@name}"
+
+  = form_with url: modal_contact_path(@id), method: :patch, data: { action: "turbo:submit-end->loco-modal#close" } do |f|
+    = f.label :name, class: "block mb-1 font-semibold"
+    = f.text_field :name, value: @name, class: "input w-full"
+
+    .flex.flex-row.items-center.justify-end.gap-2.mt-4
+      = daisy_button(css: "btn-ghost", action: "loco-modal#close", html: { type: "button" }) do
+        Cancel
+      = daisy_button(css: "btn-primary", html: { type: "submit" }) do
+        Save

--- a/docs/demo/config/routes.rb
+++ b/docs/demo/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   # Dynamic route which shows various examples
   get "/examples/:id", to: "examples#discover"
 
+  # Demo-only endpoints backing the Modal "Global Modal (Turbo Frame)" example.
+  resources :modal_contacts, only: %i[edit update], path: "modal-contacts"
+
   get "/api-docs", to: "api_docs#index"
 
   # Guides route that matches /guides/some-guide to the corresponding guide file

--- a/docs/demo/e2e/daisy/actions/modals.spec.ts
+++ b/docs/demo/e2e/daisy/actions/modals.spec.ts
@@ -14,9 +14,13 @@ test('page loads', async ({ page }) => {
   await loco.expectPageTitle(page, /Modals | LocoMotion/);
   await loco.expectPageHeadings(page, [
     'Simple Modal',
-    'Custom Activator',
-    'Global Modal'
+    'Custom Activator'
   ]);
+
+  // "Global Modal" is a prefix of "Global Modal (Turbo Frame)", so assert each
+  // exactly to avoid an ambiguous (non-exact) heading match.
+  await expect(page.getByRole('heading', { name: 'Global Modal', exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Global Modal (Turbo Frame)', exact: true })).toBeVisible();
 });
 
 /**
@@ -135,5 +139,41 @@ test.describe('global modal controller', () => {
     // The controller turned the non-bubbling native `close` into a bubbling
     // `loco-modal:close`, which the demo's document-level listener caught.
     await expect(page.getByText('loco-modal:close fired', { exact: false })).toBeVisible();
+  });
+});
+
+/**
+ * Test suite for the Global Modal Turbo Frame pattern: a remote link streams an
+ * edit form into the modal's `<turbo-frame>`, the `loco-modal` controller opens
+ * the dialog on `turbo:frame-load`, and a successful submit closes it
+ * (`turbo:submit-end -> loco-modal#close`).
+ */
+test.describe('global modal turbo frame', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/examples/Daisy::Actions::ModalComponent');
+
+    // Wait for the dialog's controller to connect so its frame-load listener is
+    // wired before we trigger a frame navigation.
+    await page.waitForFunction(() => {
+      const dialog = document.getElementById('contact-modal-dialog');
+      return !!(dialog && (window as any).Stimulus
+        && (window as any).Stimulus.getControllerForElementAndIdentifier(dialog, 'loco-modal'));
+    });
+  });
+
+  test('opens when a link loads the frame, and closes on submit', async ({ page }) => {
+    const dialog = page.locator('#contact-modal-dialog');
+    await expect(dialog).toBeHidden();
+
+    // A remote edit link streams its form into the modal's turbo-frame.
+    await page.getByRole('link', { name: 'Edit Contact 1' }).click();
+
+    // The controller opens the dialog once the frame finishes loading.
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Edit Alice Anderson')).toBeVisible();
+
+    // Submitting the form closes the dialog (turbo:submit-end -> loco-modal#close).
+    await dialog.getByRole('button', { name: 'Save' }).click();
+    await expect(dialog).toBeHidden();
   });
 });

--- a/spec/components/daisy/actions/modal_component_spec.rb
+++ b/spec/components/daisy/actions/modal_component_spec.rb
@@ -235,4 +235,22 @@ RSpec.describe Daisy::Actions::ModalComponent, type: :component do
       expect(page).not_to have_css '[tabindex="0"]'
     end
   end
+
+  context "with a turbo_frame" do
+    let(:modal) { described_class.new(trigger: false, turbo_frame: "contact-modal") }
+
+    before do
+      render_inline(modal)
+    end
+
+    describe "rendering" do
+      it "renders an empty turbo-frame with the given id inside the box" do
+        expect(page).to have_css "dialog.modal .modal-box turbo-frame#contact-modal"
+      end
+
+      it "exposes the frame id to the controller via a Stimulus value" do
+        expect(page).to have_css 'dialog.modal[data-loco-modal-turbo-frame-value="contact-modal"]'
+      end
+    end
+  end
 end

--- a/spec/components/daisy/actions/modal_component_spec.rb
+++ b/spec/components/daisy/actions/modal_component_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Daisy::Actions::ModalComponent, type: :component do
   end
 
   context "with a turbo_frame" do
-    let(:modal) { described_class.new(trigger: false, turbo_frame: "contact-modal") }
+    let(:modal) { described_class.new(trigger: false, turbo_frame_id: "contact-modal") }
 
     before do
       render_inline(modal)
@@ -249,7 +249,7 @@ RSpec.describe Daisy::Actions::ModalComponent, type: :component do
       end
 
       it "exposes the frame id to the controller via a Stimulus value" do
-        expect(page).to have_css 'dialog.modal[data-loco-modal-turbo-frame-value="contact-modal"]'
+        expect(page).to have_css 'dialog.modal[data-loco-modal-turbo-frame-id-value="contact-modal"]'
       end
     end
   end


### PR DESCRIPTION
## Context

This is the third and final PR of the Modal "Global Modal" series (see `docs/plans/202606-1-modal-global-dialog.md`). PR A (#163) added `trigger: false` to render just the `<dialog>`, and PR B (#166) added the `loco-modal` Stimulus controller with `open`/`close` actions and lifecycle events. This PR delivers the canonical Hotwire pattern end to end: a single modal that lives once in your layout and is filled on demand by a `<turbo-frame>`.

Pass a `turbo_frame_id:` (together with `trigger: false`) and the modal renders an empty `<turbo-frame>` with that id and wires the controller to open the dialog the moment that frame finishes loading remote content — and to clear the frame on close so reopening refetches. Any link with `data-turbo-frame="<id>"` now streams its content into that one shared modal and pops it open, with no per-row modals and no inline JavaScript.

## Related Issues

Fixes #161.

Fixes #16 — the `loco-modal` controller (PR B, #166) plus this Turbo-frame integration deliver the Stimulus-controller-based modal that #16 asked for, so this closes it too. Note that #16 still carries a `wontfix` label from before #161 became its concrete use case; it can be dropped on merge.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition

## Description

- **`turbo_frame_id:` option** on `ModalComponent`: renders an empty `<turbo-frame>` with that id (a new `:turbo_frame` part) inside the modal box and exposes it to the controller as the `turboFrameId` Stimulus value (`data-loco-modal-turbo-frame-id-value`).
- **Controller** (`modal_controller.js`): adds `static values = { turboFrame: String }`; on connect it opens the dialog on the frame's `turbo:frame-load` and empties the frame on close so reopening refetches. `open()` is now idempotent, so a frame-load triggered by a form submit (which replaces the frame) never re-calls `showModal()`.
- **Backward compatible**: `turbo_frame_id:` is opt-in and defaults to off, so existing modals are untouched.
- **Demo**: a "Global Modal (Turbo Frame)" example — a contact list whose edit links stream an edit form into one shared modal — backed by a tiny demo-only `ModalContacts` controller (`edit` returns the frame; `update` returns `204 No Content` so the form's `turbo:submit-end -> loco-modal#close` closes the dialog without replacing the frame).
- **Tests**: an RSpec context (the frame renders in the box and the controller value attribute is set) and an e2e covering open-on-frame-load and close-on-submit.
- **Docs**: a YARD `@option turbo_frame` entry and a Turbo Frame `@loco_example`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Verification: `just loco-test` (1202 examples, 0 failures), `just demo-test` (72, 0 failures), and the Modals Playwright suite (8/8, chromium) — including the new Turbo-Frame test. Scope is 10 files / ~246 lines, within the repo's 500-line / 10-file limit.

Per the plan's caveat, the close/cancel e2e assertions run on chromium only — some headless WebKit builds don't fire the `<dialog>` `close` event even though `showModal()`/`close()` work.
