### PR TITLE
fix(Select): Honor value: for block-form options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `trigger: false` this delivers the canonical Hotwire "Global Modal" pattern: one modal in your layout,
   opened by pointing `data-turbo-frame` links at the frame id — no per-row modals or inline JavaScript.
   Refs #161, #16.
+- fix(Select): Honor the select's `value:` when options are defined with the block form
+  (`select.with_option`). Previously only the `options:` array form preselected the matching option; block
+  options always rendered unselected unless you passed `selected:` on every one — so form-builder edit forms
+  (`f.daisy_select :branch_id`) showed the first option instead of the record's saved value. Block options now
+  default their selected state from the parent `value:`, and an explicit `selected:` on an option still wins.
+  Fixes #171.
 
 ### Demo / Docs Changes
 
@@ -104,6 +110,9 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - docs(Modal): Add a "Global Modal (Turbo Frame)" demo example — a contact list whose edit links stream an
   edit form into one shared modal via a `<turbo-frame>` — backed by a small demo-only `ModalContacts`
   controller, plus a Turbo Frame `@loco_example` and `@option turbo_frame_id` in the component's YARD.
+- docs(Demo): Update the Selects "Pre-Selected Value" example to preselect through the select's `value:`
+  attribute (now honored for block options) instead of a per-option `selected:`, matching what the example's
+  description already described.
 
 ### Fixed
 

--- a/app/components/daisy/data_input/select_component.rb
+++ b/app/components/daisy/data_input/select_component.rb
@@ -276,19 +276,26 @@ module Daisy
 
         # Add options from the block or default options
         if options?
-          # Block options render verbatim, so default each one's `selected`
-          # state from the parent `value:` (matching the `options:` array path)
-          # unless the caller set it explicitly.
-          options.each do |option|
-            option.selected = (option.value.to_s == @value.to_s) if option.selected.nil?
-          end
-
-          result << safe_join(options.map(&:call))
+          result << safe_join(block_options.map(&:call))
         elsif default_options.present?
           result << safe_join(default_options.map { |option| render(option) })
         end
 
         result.html_safe
+      end
+
+      #
+      # Returns the block-form options, defaulting each one's `selected` state
+      # from the parent `value:` (matching the `options:` array path) unless the
+      # caller set `selected:` explicitly. Block options render verbatim, so
+      # this is where they inherit the select's value.
+      #
+      # @return [Array<SelectOptionComponent>] The options to render.
+      #
+      def block_options
+        options.each do |option|
+          option.selected = (option.value.to_s == @value.to_s) if option.selected.nil?
+        end
       end
 
       #

--- a/app/components/daisy/data_input/select_component.rb
+++ b/app/components/daisy/data_input/select_component.rb
@@ -46,7 +46,12 @@ module Daisy
       include LocoMotion::Concerns::AriableComponent
 
       class SelectOptionComponent < LocoMotion::BasicComponent
-        attr_reader :value, :label, :selected, :disabled
+        attr_reader :value, :label, :disabled
+
+        # Writable so the parent {SelectComponent} can default it from its
+        # `value:` when the caller didn't set it explicitly (see
+        # {SelectComponent#render_select_options}).
+        attr_accessor :selected
 
         #
         # Initialize a new select option component.
@@ -55,7 +60,10 @@ module Daisy
         #
         # @param label [String] The label to display for the option.
         #
-        # @param selected [Boolean] Whether the option is selected. Defaults to false.
+        # @param selected [Boolean, nil] Whether the option is selected. Defaults
+        #   to `nil`, which means "inherit" — the parent select marks the option
+        #   selected when its `value` matches the select's `value:`. Pass `true`
+        #   or `false` to override that and force the option's selected state.
         #
         # @param disabled [Boolean] Whether the option is disabled. Defaults to false.
         #
@@ -64,7 +72,7 @@ module Daisy
         # @param html [Hash] HTML attributes to apply to the option.
         #
         # rubocop:disable Metrics/ParameterLists
-        def initialize(value:, label:, selected: false, disabled: false, css: "", html: {}, **kws)
+        def initialize(value:, label:, selected: nil, disabled: false, css: "", html: {}, **kws)
           @value = value
           @label = label
           @selected = selected
@@ -268,6 +276,13 @@ module Daisy
 
         # Add options from the block or default options
         if options?
+          # Block options render verbatim, so default each one's `selected`
+          # state from the parent `value:` (matching the `options:` array path)
+          # unless the caller set it explicitly.
+          options.each do |option|
+            option.selected = (option.value.to_s == @value.to_s) if option.selected.nil?
+          end
+
           result << safe_join(options.map(&:call))
         elsif default_options.present?
           result << safe_join(default_options.map { |option| render(option) })

--- a/docs/demo/app/views/examples/daisy/data_input/selects.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/selects.html.haml
@@ -156,13 +156,16 @@
 = doc_example(title: "Pre-Selected Value") do |doc|
   - doc.with_description do
     :markdown
-      Select inputs can have a pre-selected value by setting the `value` attribute.
+      Select inputs can have a pre-selected value by setting the `value`
+      attribute. The matching option is selected automatically whether the
+      options come from the `options:` array or are defined with the block
+      form. Pass `selected:` on an individual `with_option` to override it.
 
   .my-2.space-y-2
     = daisy_label(for: "preselected_select", title: "Pre-Selected Select")
-    = daisy_select(name: "preselected_select", id: "preselected_select", placeholder: "Select a country") do |select|
+    = daisy_select(name: "preselected_select", id: "preselected_select", value: "ca", placeholder: "Select a country") do |select|
       - select.with_option(value: "us", label: "United States")
-      - select.with_option(value: "ca", label: "Canada", selected: true)
+      - select.with_option(value: "ca", label: "Canada")
       - select.with_option(value: "mx", label: "Mexico")
 
 

--- a/spec/components/daisy/data_input/select_component_spec.rb
+++ b/spec/components/daisy/data_input/select_component_spec.rb
@@ -71,6 +71,48 @@ RSpec.describe Daisy::DataInput::SelectComponent, type: :component do
     expect(page).to have_css("option[value='option2']", text: "Option 2")
   end
 
+  it "selects the block option matching the parent value:" do
+    component = described_class.new(name: "test", id: "test", value: "option2")
+    render_inline(component) do |c|
+      c.with_option(value: "option1", label: "Option 1")
+      c.with_option(value: "option2", label: "Option 2")
+    end
+
+    expect(page).to have_css("option[value='option1']:not([selected])")
+    expect(page).to have_css("option[value='option2'][selected]")
+  end
+
+  it "matches the parent value: against block options regardless of type" do
+    component = described_class.new(name: "test", id: "test", value: 2)
+    render_inline(component) do |c|
+      c.with_option(value: 1, label: "One")
+      c.with_option(value: 2, label: "Two")
+    end
+
+    expect(page).to have_css("option[value='2'][selected]")
+  end
+
+  it "lets an explicit selected: on a block option override the parent value:" do
+    component = described_class.new(name: "test", id: "test", value: "option2")
+    render_inline(component) do |c|
+      c.with_option(value: "option1", label: "Option 1", selected: true)
+      c.with_option(value: "option2", label: "Option 2", selected: false)
+    end
+
+    expect(page).to have_css("option[value='option1'][selected]")
+    expect(page).to have_css("option[value='option2']:not([selected])")
+  end
+
+  it "selects no block option when the parent value: is absent" do
+    component = described_class.new(name: "test", id: "test")
+    render_inline(component) do |c|
+      c.with_option(value: "option1", label: "Option 1")
+      c.with_option(value: "option2", label: "Option 2")
+    end
+
+    expect(page).to have_css("option:not([selected])", count: 2)
+  end
+
   it "renders a select component with options_css applied to each option" do
     options = ["Option 1", "Option 2"]
     component = described_class.new(name: "test", id: "test", options: options, options_css: "text-primary")


### PR DESCRIPTION
## Context

Building edit forms with `f.daisy_select :branch_id`, the record's saved value wasn't preselected when the options were defined with the **block form** (`select.with_option`). You'd open an edit form and see the first option instead of the value already on the record — surprising, and easy to miss.

Root cause: block options render verbatim, so each option's `selected` stayed at its `false` default and was never compared to the select's `value:`. Only the `options:` array path computed selection from `value:`, so the two documented ways of supplying options behaved differently.

## Related Issues

Fixes #171

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

- `SelectComponent::SelectOptionComponent#selected` now defaults to `nil` ("inherit") instead of `false`, and is writable.
- When rendering block options, the select defaults each option's `selected` from its own `value:` (matching the `options:` array path) **unless** the caller passed `selected:` explicitly — so an explicit `selected:` still wins.
- Updated the demo's "Pre-Selected Value" example to preselect via `value:` (which now works for block options) instead of the per-option `selected:` workaround, matching the description it already had.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Library suite green (1206 examples, 0 failures). The match is type-agnostic (`value.to_s == @value.to_s`), so integer ids from form objects match string option values.
