### PR TITLE
feat(Fieldset): Add a caption / helper-text slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   applied `data-theme` when nothing is saved in `localStorage`, so `setInput` marks the active row/checkmark
   on first visit (e.g. a server-rendered or preload-applied theme) instead of leaving every option unmarked
   until the user picks one. Saved choices still win. Refs #165.
+- feat(Fieldset): Add a caption / helper-text slot to `daisy_fieldset`. Provide it with the `caption` slot
+  (`fieldset.with_caption`) or the `caption:` argument, and it renders below the controls using DaisyUI's
+  `.fieldset-label`. Unlike `.label` (`daisy_label`), `.fieldset-label` is not `white-space: nowrap`, so long
+  help text wraps instead of pushing the form off-screen. `.fieldset-label` is `display: flex`; for prose with
+  an inline link, pass `caption_css: "block"` so the link flows inside the sentence. Fixes #162.
 
 ### Demo / Docs Changes
 
@@ -123,6 +128,9 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")`. The rule lives in the
   demo's `application.tailwind.css` for now and is slated to move into the shipped LocoMotion CSS file (#170).
   Added a "Sticky Floating Label" demo example and a Playwright check that the label stays raised. Fixes #169.
+- docs(Fieldset): Add two Fieldsets demo examples for the new caption slot — one using the `caption:` argument
+  and one using the `caption` slot with `css: "block"` for a caption containing an inline link — plus a smoke
+  check for both in the Playwright spec.
 
 ### Fixed
 

--- a/app/components/daisy/data_input/fieldset_component.html.haml
+++ b/app/components/daisy/data_input/fieldset_component.html.haml
@@ -6,3 +6,9 @@
 
   -# Render the main content passed to the component block
   = content
+
+  -# Render the caption / helper text (.fieldset-label) below the content
+  - if caption?
+    = caption
+  - elsif @simple_caption
+    = part(:caption) { @simple_caption }

--- a/app/components/daisy/data_input/fieldset_component.rb
+++ b/app/components/daisy/data_input/fieldset_component.rb
@@ -5,6 +5,23 @@ module Daisy
     # Renders a fieldset element, optionally with a legend, to group
     # related form controls or content.
     #
+    # @note Use the `caption` slot (or the `caption:` argument) for caption /
+    #   helper text below the controls — it renders DaisyUI's
+    #   `.fieldset-label`, which (unlike `.label` / `daisy_label`) is **not**
+    #   `white-space: nowrap`, so long help text wraps instead of pushing the
+    #   form off-screen. `.fieldset-label` is `display: flex`, which splits a
+    #   sentence and an inline link into separate flex items; for prose that
+    #   contains a link, pass `caption_css: "block"` so the link flows inside
+    #   the sentence.
+    #
+    # @part legend The `<legend>` element rendered for the `legend:` argument.
+    # @part caption The `<div class="fieldset-label">` caption rendered for the
+    #   `caption:` argument.
+    #
+    # @slot legend Custom content for the legend (title).
+    # @slot caption Custom content for the caption / helper text shown below the
+    #   fieldset's controls.
+    #
     # @loco_example Basic fieldset
     #   = daisy_fieldset do
     #     Content inside fieldset
@@ -19,19 +36,41 @@ module Daisy
     #   = daisy_fieldset(legend: "My Legend") do
     #     Content inside fieldset
     #
+    # @loco_example Fieldset with caption / helper text
+    #   = daisy_fieldset(legend: "Theme", caption: "Used for newly created charts.") do
+    #     = daisy_select(options: ["Light", "Dark"])
+    #
+    # @loco_example Caption with an inline link (override the flex display)
+    #   = daisy_fieldset(legend: "Theme") do |fieldset|
+    #     = daisy_select(options: ["Light", "Dark"])
+    #     - fieldset.with_caption(css: "block") do
+    #       Manage themes on the
+    #       = link_to "Themes", "/themes"
+    #       page.
+    #
     class FieldsetComponent < LocoMotion::BaseComponent
       self.component_name = :fieldset
 
-      define_parts :legend
+      define_parts :legend, :caption
 
       # The legend (title) for the fieldset. Renders a `<legend>` tag.
       # Can be provided as a slot or via the `legend` argument.
       renders_one :legend, LocoMotion::BasicComponent.build(tag_name: :legend, css: "fieldset-legend")
 
+      # The caption / helper text for the fieldset. Renders a
+      # `<div class="fieldset-label">` after the content. Can be provided as a
+      # slot or via the `caption` argument.
+      renders_one :caption, LocoMotion::BasicComponent.build(tag_name: :div, css: "fieldset-label")
+
       # @param legend [String] Optional simple text for the legend.
       #   Ignored if the `legend` slot is used.
-      def initialize(legend: nil, **kws)
+      #
+      # @param caption [String] Optional simple caption / helper text rendered
+      #   below the content using DaisyUI's `.fieldset-label`. Ignored if the
+      #   `caption` slot is used.
+      def initialize(legend: nil, caption: nil, **kws)
         @simple_legend = legend
+        @simple_caption = caption
 
         super(**kws)
       end
@@ -48,8 +87,10 @@ module Daisy
       def setup_component
         set_tag_name(:component, :fieldset)
         set_tag_name(:legend, :legend)
+        set_tag_name(:caption, :div)
 
         add_css(:legend, "fieldset-legend")
+        add_css(:caption, "fieldset-label")
         add_css(:component, "fieldset")
       end
     end

--- a/docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml
@@ -57,3 +57,31 @@
     = daisy_label("API Key")
     = daisy_input(placeholder: "asdf1234")
     = daisy_button("Save Settings", css: "mt-4")
+
+
+= doc_example(title: "Fieldset with Caption (Argument)") do |doc|
+  - doc.with_description do
+    :markdown
+      Pass `caption:` to add caption / helper text below the controls. It
+      renders DaisyUI's `.fieldset-label`, which — unlike `.label`
+      (`daisy_label`) — is not `nowrap`, so long help text wraps instead of
+      overflowing the form.
+
+  = daisy_fieldset(legend: "Display Name", caption: "This is shown publicly on your profile and in comments.", css: "w-80") do
+    = daisy_input(placeholder: "Ada Lovelace")
+
+
+= doc_example(title: "Fieldset Caption with an Inline Link") do |doc|
+  - doc.with_description do
+    :markdown
+      `.fieldset-label` is `display: flex`, which splits a sentence and an
+      inline link into separate flex items. For prose that contains a link, use
+      the `caption` slot and pass `css: "block"` so the link flows inside the
+      sentence.
+
+  = daisy_fieldset(legend: "Theme", css: "w-80") do |fieldset|
+    = daisy_select(options: ["Light", "Dark", "System"], placeholder: "Select a theme")
+    - fieldset.with_caption(css: "block") do
+      Pick the palette used for new charts. Manage your saved themes on the
+      = daisy_link("Themes", href: "#")
+      page.

--- a/docs/demo/e2e/daisy/data_input/fieldsets.spec.ts
+++ b/docs/demo/e2e/daisy/data_input/fieldsets.spec.ts
@@ -14,6 +14,8 @@ test('page loads', async ({ page }) => {
     'Fieldset with Legend (Argument)',
     'Fieldset with Legend (Slot)',
     'Fieldset with Various Inputs',
-    'Fieldset with Custom Styling'
+    'Fieldset with Custom Styling',
+    'Fieldset with Caption (Argument)',
+    'Fieldset Caption with an Inline Link'
   ]);
 });

--- a/spec/components/daisy/data_input/fieldset_component_spec.rb
+++ b/spec/components/daisy/data_input/fieldset_component_spec.rb
@@ -71,4 +71,57 @@ RSpec.describe Daisy::DataInput::FieldsetComponent, type: :component do
 
     expect(page).to have_css("legend.fieldset-legend.custom-legend-class", text: "Simple Legend")
   end
+
+  it "renders a caption from the caption argument" do
+    render_inline(described_class.new(caption: "Helper text")) do
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset div.fieldset-label", text: "Helper text")
+  end
+
+  it "renders a caption from the caption slot" do
+    render_inline(described_class.new) do |c|
+      c.with_caption { "Slot caption" }
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset div.fieldset-label", text: "Slot caption")
+  end
+
+  it "prioritizes the caption slot over the argument" do
+    render_inline(described_class.new(caption: "Argument caption")) do |c|
+      c.with_caption { "Slot caption" }
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("div.fieldset-label", text: "Slot caption")
+    expect(page).not_to have_css("div.fieldset-label", text: "Argument caption")
+  end
+
+  it "renders the caption after the content" do
+    render_inline(described_class.new(legend: "Title", caption: "Caption")) do
+      "Fieldset Content"
+    end
+
+    # The caption is the fieldset's last child, after the content.
+    expect(page).to have_css("fieldset > div.fieldset-label:last-child", text: "Caption")
+  end
+
+  it "lets the caption display be overridden for prose with inline links" do
+    render_inline(described_class.new) do |c|
+      c.with_caption(css: "block") { "See the docs" }
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("div.fieldset-label.block", text: "See the docs")
+  end
+
+  it "omits the caption when no caption is provided" do
+    render_inline(described_class.new(legend: "Title")) do
+      "Fieldset Content"
+    end
+
+    expect(page).not_to have_css(".fieldset-label")
+  end
 end


### PR DESCRIPTION
## Context

Building forms with `daisy_fieldset`, there was no first-class way to render caption / helper text under a control. The only label-ish helper, `daisy_label`, renders DaisyUI's `.label`, which is `display: inline-flex; white-space: nowrap` — meant for short prefix/suffix labels inside an input. Used for a long helper sentence it can't wrap, so the text (and the inputs it drags along) runs off-screen — especially painful inside a modal.

DaisyUI's fieldset anatomy is `fieldset-legend` (title) + control + a caption, and it ships a dedicated caption class, `.fieldset-label` (muted 60%, and — crucially — **not** `nowrap`, so it wraps). That class wasn't exposed by any LocoMotion helper.

## Related Issues

Fixes #162

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition

## Description

Adds a **caption** slot to `daisy_fieldset`, following the existing `legend` pattern:

- `fieldset.with_caption do … end` (slot) or the `caption:` argument, rendered as `<div class="fieldset-label">` **below the controls**.
- `.fieldset-label` wraps long help text instead of overflowing the form.
- One caveat handled: `.fieldset-label` is `display: flex`, which splits a sentence and an inline link into separate flex items. For prose containing a link, pass `caption_css: "block"` (or `css: "block"` on the slot) so the link flows inside the sentence — DaisyUI 5's layering lets the utility win over the component class. Both paths are demoed.

The part/slot/option is named **`caption`** (not `label`) per review — LocoMotion already uses `label` to mean something else, so even though it renders DaisyUI's `.fieldset-label` class, the API is `caption`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Library suite green; the Fieldsets Playwright smoke test passes with the two new example headings. Verified the demo page renders (HTTP 200) and the slot emits `class="block fieldset-label"` for the inline-link example.

Scoped to the caption slot (issue Option A). The standalone `daisy_fieldset_label` helper (Option B) and a `.label`-is-nowrap warning on `daisy_label` (Option C) are intentionally left out to keep this one concern.
