### PR TITLE
feat(Demo): Add a floating-sticky CSS variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - docs(Demo): Update the Selects "Pre-Selected Value" example to preselect through the select's `value:`
   attribute (now honored for block options) instead of a per-option `selected:`, matching what the example's
   description already described.
+- feat(Demo): Add a `floating-sticky` CSS variant that pins a DaisyUI floating label in its raised position
+  even while the field is empty and showing a placeholder, so the label and the placeholder hint show at once
+  (a Material-style label). Opt in by adding it to the label wrapper, e.g. `daisy_text_input(floating:
+  "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")`. The rule lives in the
+  demo's `application.tailwind.css` for now and is slated to move into the shipped LocoMotion CSS file (#170).
+  Added a "Sticky Floating Label" demo example and a Playwright check that the label stays raised. Fixes #169.
 
 ### Fixed
 

--- a/docs/demo/app/assets/stylesheets/application.tailwind.css
+++ b/docs/demo/app/assets/stylesheets/application.tailwind.css
@@ -50,3 +50,29 @@
     --tt-pos: 0rem;
   }
 }
+
+/*
+ * `floating-sticky` — keep a DaisyUI floating label in its raised position even
+ * while the field is empty and showing a placeholder. By default DaisyUI only
+ * raises the label on focus or once the field has a value (an empty field with
+ * a placeholder matches `:placeholder-shown`, which keeps the label collapsed),
+ * so a placeholder hint and a raised floating label never appear together. Add
+ * `floating-sticky` alongside `floating-label` (e.g. via `label_wrapper_css:`)
+ * to pin the label up, leaving the placeholder visible inside the empty field
+ * for a Material-style label.
+ *
+ * Mirrors DaisyUI's own raised-state declaration; the raised values are
+ * size-independent, so this single rule covers every input size. Because it is
+ * unlayered it also wins over DaisyUI's disabled rule
+ * (`:has(:disabled) > span { opacity: 0 }`), so the label stays visible on
+ * disabled fields too. Slated to move into the shipped LocoMotion CSS file
+ * (#170); see #169.
+ */
+.floating-label.floating-sticky > span {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 2;
+  top: 0;
+  translate: -12.5% calc(-50% - .125em);
+  scale: .75;
+}

--- a/docs/demo/app/views/examples/daisy/data_input/text_inputs.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/text_inputs.html.haml
@@ -52,6 +52,25 @@
       = daisy_text_input(name: "fax_floating_input", id: "fax_floating_input", floating: "Fax", placeholder: "fax: (123) 456-7890")
 
 
+= doc_example(title: "Sticky Floating Label") do |doc|
+  - doc.with_description do
+    :markdown
+      By default a floating label collapses back into the field while it is empty
+      and showing a placeholder, only rising on focus. Add the `floating-sticky`
+      class (a LocoMotion variant) via `label_wrapper_css:` to pin the label in
+      its raised position, so the label and the placeholder hint show at the same
+      time.
+
+      Tip: for an always-raised label with **no** placeholder, just pass
+      `floating:` without a `placeholder:` — DaisyUI keeps that label raised on
+      its own (see the first group of the previous example).
+
+  .flex.flex-col.gap-4
+    .space-y-4
+      = daisy_text_input(name: "email_sticky_input", id: "email_sticky_input", floating: "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")
+      = daisy_text_input(name: "company_sticky_input", id: "company_sticky_input", floating: "Company", placeholder: "Acme, Inc.", label_wrapper_css: "floating-sticky")
+
+
 = doc_example(title: "Different Input Types") do |doc|
   - doc.with_description do
     :markdown

--- a/docs/demo/e2e/daisy/data_input/text_inputs.spec.ts
+++ b/docs/demo/e2e/daisy/data_input/text_inputs.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { loco } from '../../spec_helpers';
 
 test('page loads', async ({ page }) => {
@@ -12,6 +12,7 @@ test('page loads', async ({ page }) => {
   await loco.expectPageHeadings(page, [
     'Basic Text Input',
     'Floating Label Inputs',
+    'Sticky Floating Label',
     'Different Input Types',
     'Text Input Sizes',
     'Text Input with Different Colors',
@@ -21,4 +22,26 @@ test('page loads', async ({ page }) => {
     'Text Input with Icons',
     'Rails Form Example'
   ]);
+});
+
+// Returns the computed opacity of a floating label's <span> for the input with
+// the given id. DaisyUI collapses the span to opacity 0 and only raises it
+// (opacity 1) on focus or once the field has a value.
+const floatingLabelOpacity = (page, inputId: string) =>
+  page
+    .locator('label.floating-label', { has: page.locator(`#${inputId}`) })
+    .locator('span')
+    .first()
+    .evaluate((el) => getComputedStyle(el).opacity);
+
+test('floating-sticky keeps the label raised while a placeholder shows', async ({ page }) => {
+  await page.goto('/');
+  await loco.clickNavLink(page, 'Text Inputs');
+
+  // The sticky field is empty and shows a placeholder, yet its label is raised.
+  expect(await floatingLabelOpacity(page, 'email_sticky_input')).toBe('1');
+
+  // A plain floating field with a placeholder keeps its label collapsed until
+  // focus — proving floating-sticky (not some other change) is what raised it.
+  expect(await floatingLabelOpacity(page, 'phone_floating_input')).toBe('0');
 });


### PR DESCRIPTION
## Context

LocoMotion's labelable inputs support a DaisyUI floating label via `floating:` / `floating_placeholder:`. When a placeholder is present, DaisyUI keeps the label collapsed inside the field and only raises it on focus (an empty field with a placeholder matches `:placeholder-shown`). So a placeholder hint and a raised floating label never show together — there was no way to keep a floating label permanently raised, a common Material-style pattern.

## Related Issues

Fixes #169

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Description

Adds a `floating-sticky` CSS variant (a companion to `.floating-label`) that pins the label span to the raised state regardless of placeholder/focus — no new component option, keeping with LocoMotion's "apply CSS classes directly" convention:

```haml
= daisy_text_input(floating: "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")
```

- The rule mirrors DaisyUI's own raised-state declaration; the raised values are size-independent, so one rule covers every input size.
- It's **unlayered**, so it wins over DaisyUI's layered `.floating-label > span { opacity: 0 }` and its `:has(:disabled) > span { opacity: 0 }` (a disabled sticky field still shows its label — documented inline).
- For now the rule lives in the demo's `application.tailwind.css`; its canonical home will be the importable LocoMotion CSS file in #170.

Also documents the zero-config alternative: pass `floating:` **without** a placeholder and DaisyUI already keeps the label raised.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

The Playwright test asserts the sticky label's computed `opacity` is `1` (raised) while a plain placeholder field's stays `0` (collapsed) — which directly verifies the unlayered rule wins the cascade over DaisyUI's `opacity: 0`. Both text-input e2e tests pass.

Follow-ups tracked in the issue: move the rule into the shipped CSS file (#170), and propose a native `floating-label-sticky` modifier upstream to DaisyUI.
