### PR TITLE
feat(ThemePreview): Register a daisy_theme_preview helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   applied `data-theme` when nothing is saved in `localStorage`, so `setInput` marks the active row/checkmark
   on first visit (e.g. a server-rendered or preload-applied theme) instead of leaving every option unmarked
   until the user picks one. Saved choices still win. Refs #165.
+- feat(ThemePreview): Register a top-level `daisy_theme_preview` helper for `ThemePreviewComponent`, so theme
+  swatches can be composed anywhere instead of only via `tc.build_theme_preview` or rendering the class
+  directly. (The component's YARD already documented `daisy_theme_preview`; the helper now actually exists.)
+  Refs #165.
 
 ### Demo / Docs Changes
 
@@ -123,6 +127,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")`. The rule lives in the
   demo's `application.tailwind.css` for now and is slated to move into the shipped LocoMotion CSS file (#170).
   Added a "Sticky Floating Label" demo example and a Playwright check that the label stays raised. Fixes #169.
+- docs(ThemePreview): Add a "Theme Previews" demo page (registered under Actions) showing the
+  `daisy_theme_preview` helper across themes and sizes, with a Playwright page-loads check.
 
 ### Fixed
 

--- a/docs/demo/app/views/examples/daisy/actions/theme_previews.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/theme_previews.html.haml
@@ -1,0 +1,33 @@
+= doc_title(title: "Theme Previews", comp: @comp) do |title|
+  :markdown
+    The Theme Preview shows a small swatch of a DaisyUI theme's colors — a 2×2
+    grid of dots for the `base-content`, `primary`, `secondary`, and `accent`
+    colors. Use it on its own with the `daisy_theme_preview` helper, or as a
+    building block inside a custom theme switcher (see the
+    #{component_link("Theme Controller", "Daisy::Actions::ThemeControllerComponent")}).
+
+
+= doc_example(title: "Basic Usage") do |doc|
+  - doc.with_description do
+    :markdown
+      Pass a `theme:` name (as a positional or keyword argument) to preview any
+      DaisyUI theme that's enabled in your `daisyui` plugin config.
+
+  .flex.flex-wrap.gap-4.items-start
+    - %w[light dark synthwave retro cyberpunk wireframe].each do |theme|
+      .flex.flex-col.items-center.gap-1
+        = daisy_theme_preview(theme: theme)
+        %span.text-xs.capitalize= theme
+
+
+= doc_example(title: "Custom Size") do |doc|
+  - doc.with_description do
+    :markdown
+      The preview uses a zero-specificity `where:size-4` default, so any `size-*`
+      utility you pass via `css:` overrides it.
+
+  .flex.gap-4.items-end
+    = daisy_theme_preview(theme: "synthwave", css: "size-4")
+    = daisy_theme_preview(theme: "synthwave", css: "size-6")
+    = daisy_theme_preview(theme: "synthwave", css: "size-8")
+    = daisy_theme_preview("synthwave", css: "size-12")

--- a/docs/demo/e2e/daisy/actions/theme_previews.spec.ts
+++ b/docs/demo/e2e/daisy/actions/theme_previews.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@playwright/test';
+import { loco } from '../../spec_helpers';
+
+test('page loads', async ({ page }) => {
+  await page.goto('/');
+
+  // Click the Theme Previews nav link
+  await loco.clickNavLink(page, 'Theme Previews');
+
+  // Expect the title and key headings
+  await loco.expectPageTitle(page, /Theme Previews | LocoMotion/);
+  await loco.expectPageHeadings(page, [
+    'Basic Usage',
+    'Custom Size'
+  ]);
+});

--- a/lib/loco_motion/helpers.rb
+++ b/lib/loco_motion/helpers.rb
@@ -22,6 +22,8 @@ module LocoMotion
     "Daisy::Actions::SwapComponent" => { names: "swap", group: "Actions", title: "Swaps", example: "swaps" },
     "Daisy::Actions::ThemeControllerComponent" => { names: "theme_controller", group: "Actions",
                                                     title: "Theme Controllers", example: "theme_controllers" },
+    "Daisy::Actions::ThemePreviewComponent" => { names: "theme_preview", group: "Actions",
+                                                 title: "Theme Previews", example: "theme_previews" },
 
     # Data
     "Daisy::DataDisplay::AccordionComponent" => { names: "accordion", group: "Data Display", title: "Accordions",


### PR DESCRIPTION
## Context

Part of #165 (theme switcher ergonomics). `ThemePreviewComponent` (the little 2×2 color swatch) was only reachable via `tc.build_theme_preview` inside a `daisy_theme_controller`, or by rendering the class directly — there was no top-level helper, so you couldn't drop a preview anywhere you wanted. The component's own YARD even shows `= daisy_theme_preview(theme: "light")`, but that helper didn't actually exist.

## Related Issues

Refs #165 (does not close it — one of several ergonomics).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition

## Description

- Register `Daisy::Actions::ThemePreviewComponent` in `LocoMotion::COMPONENTS` with the name `theme_preview`, which generates the `daisy_theme_preview` helper (making the existing YARD examples real).
- Because the demo nav is built from that same map, registration also surfaces a "Theme Previews" page under **Actions** — added a demo page (themes + sizes) and a Playwright page-loads check so the new nav link works.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Library suite green (1202 examples, 0 failures). Restarted the demo (a `lib/loco_motion` change) and verified the new page renders (HTTP 200, helper resolves) and the e2e page-loads test passes. The component already had its own unit spec.
