### PR TITLE
feat(Dropdown): Add a structured, selectable dropdown item builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   applied `data-theme` when nothing is saved in `localStorage`, so `setInput` marks the active row/checkmark
   on first visit (e.g. a server-rendered or preload-applied theme) instead of leaving every option unmarked
   until the user picks one. Saved choices still win. Refs #165.
+- feat(Dropdown): Give `with_item` a structured builder for selectable menu rows. Pass `label:`, `href:`, and
+  `selected:` and use the item's `start` / `end` slots (matching our other components), and the dropdown
+  renders a proper `<li class="menu-item"><a class="… menu-active">` row instead of making you hand-roll the
+  markup. Bare content-block items (`with_item do … end`) render exactly as before, so this is fully backward
+  compatible. Refs #165.
 
 ### Demo / Docs Changes
 
@@ -123,6 +128,8 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")`. The rule lives in the
   demo's `application.tailwind.css` for now and is slated to move into the shipped LocoMotion CSS file (#170).
   Added a "Sticky Floating Label" demo example and a Playwright check that the label stays raised. Fixes #169.
+- docs(Dropdown): Add a "Selectable Items" demo example using the new structured `with_item` builder
+  (`start` icon, label, `end` checkmark, and a `selected` active row).
 
 ### Fixed
 

--- a/app/components/daisy/actions/dropdown_component.rb
+++ b/app/components/daisy/actions/dropdown_component.rb
@@ -18,8 +18,9 @@
 #   and is styled automatically.
 # @slot activator A custom (i.e. non-button) activator for the dropdown.
 #   Automatically adds the `role="button"` and `tabindex="0"` attributes.
-# @slot item+ The items in the dropdown. Each item will be styled consistently
-#   with proper spacing and hover states.
+# @slot item+ The items in the dropdown. Pass a block for fully custom content,
+#   or use the structured options (`label:`, `href:`, `selected:`) and the
+#   item's `start` / `end` slots to build a selectable row.
 #
 # @loco_example Basic Usage
 #   = daisy_dropdown do |dropdown|
@@ -56,16 +57,112 @@
 #         = heroicon "arrow-right-on-rectangle"
 #         Logout
 #
+# @loco_example Selectable Items (start / label / end / selected)
+#   = daisy_dropdown(title: "Sort by") do |dropdown|
+#     - dropdown.with_item(label: "Newest", href: "#", selected: true) do |item|
+#       - item.with_end do
+#         = heroicon "check", css: "size-4"
+#     - dropdown.with_item(label: "Oldest", href: "#")
+#     - dropdown.with_item(href: "#") do |item|
+#       - item.with_start do
+#         = heroicon "star", css: "size-4"
+#       Favorites
+#
 module Daisy
   module Actions
     class DropdownComponent < LocoMotion::BaseComponent
       include ViewComponent::SlotableDefault
 
+      #
+      # A single dropdown menu item (`<li class="menu-item">`). Pass a block for
+      # fully custom content (the original behavior), or use the structured
+      # options/slots to build a selectable row: a `start` slot, a label, an
+      # `end` slot, and an active (`selected`) state.
+      #
+      # @slot start Content rendered before the label (e.g. an icon or color
+      #   swatch).
+      #
+      # @slot end Content rendered after the label (e.g. a checkmark or a
+      #   shortcut hint).
+      #
+      class ItemComponent < LocoMotion::BasicComponent
+        renders_one :start
+        renders_one :end
+
+        # @option kws label [String] Text for the item's label. You can also
+        #   pass the label as block content.
+        #
+        # @option kws href [String] When present, the row is rendered as an
+        #   `<a>` link to this URL.
+        #
+        # @option kws selected [Boolean] Marks the row active, adding DaisyUI's
+        #   `menu-active` class. Defaults to false.
+        def initialize(label: nil, href: nil, selected: false, **kws)
+          @label = label
+          @href = href
+          @selected = selected
+
+          super(**kws)
+        end
+
+        def before_render
+          set_tag_name(:component, :li)
+          add_css(:component, "menu-item")
+
+          super
+        end
+
+        def call
+          part(:component) do
+            structured? ? render_row : content
+          end
+        end
+
+        private
+
+        # Render the structured row only when a structured affordance is used; a
+        # bare content block stays verbatim for backwards compatibility.
+        def structured?
+          @label.present? || @href.present? || @selected || start? || send(:end?)
+        end
+
+        def render_row
+          body = safe_join([start_content, label_content, end_content].compact)
+
+          if @href
+            link_to(@href, class: row_css) { body }
+          else
+            content_tag(:span, body, class: row_css)
+          end
+        end
+
+        def start_content
+          start if start?
+        end
+
+        def label_content
+          text = @label.presence || content
+          content_tag(:span, text, class: "grow") if text.present?
+        end
+
+        # NOTE: `end` is a reserved word, so the slot's reader/predicate (defined
+        # by `renders_one :end`) must be invoked via `send`.
+        def end_content
+          send(:end) if send(:end?)
+        end
+
+        def row_css
+          classes = %w[flex items-center gap-2]
+          classes << "menu-active" if @selected
+          classes.join(" ")
+        end
+      end
+
       define_parts :menu
 
       renders_one :activator, LocoMotion::BasicComponent.build(html: { role: "button", tabindex: 0 })
       renders_one :button, Daisy::Actions::ButtonComponent
-      renders_many :items, LocoMotion::BasicComponent.build(tag_name: :li, css: "menu-item")
+      renders_many :items, ItemComponent
 
       #
       # Creates a new instance of the DropdownComponent.

--- a/docs/demo/app/views/examples/daisy/actions/dropdowns.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/dropdowns.html.haml
@@ -33,6 +33,30 @@
       = link_to "Hotwire", "https://hotwired.dev/", target: "_blank"
 
 
+= doc_example(title: "Selectable Items", example_css: "pb-48") do |doc|
+  - doc.with_description do
+    :markdown
+      Build selectable rows without hand-rolling the markup: pass `label:`,
+      `href:`, and `selected:` to `with_item`, and use the item's `start` /
+      `end` slots for an icon and a checkmark. `selected: true` adds DaisyUI's
+      `menu-active` highlight. Items with a plain content block still render
+      exactly as before.
+
+  = daisy_dropdown(title: "Sort by", css: "dropdown-end") do |dropdown|
+    - dropdown.with_item(label: "Newest first", href: "#", selected: true) do |item|
+      - item.with_start do
+        = hero_icon "bars-arrow-down", css: "size-4"
+      - item.with_end do
+        = hero_icon "check", css: "size-4 text-primary"
+    - dropdown.with_item(label: "Oldest first", href: "#") do |item|
+      - item.with_start do
+        = hero_icon "bars-arrow-up", css: "size-4"
+    - dropdown.with_item(href: "#") do |item|
+      - item.with_start do
+        = hero_icon "star", css: "size-4"
+      Favorites
+
+
 = doc_example(title: "Fully Custom Dropdown", example_css: "flex-col") do |doc|
   - doc.with_description do
     :markdown

--- a/docs/demo/e2e/daisy/actions/dropdowns.spec.ts
+++ b/docs/demo/e2e/daisy/actions/dropdowns.spec.ts
@@ -12,6 +12,7 @@ test('page loads', async ({ page }) => {
   await loco.expectPageHeadings(page, [
     'Basic Dropdown',
     'Custom Button',
+    'Selectable Items',
     'Fully Custom Dropdown'
   ]);
 });

--- a/spec/components/daisy/actions/dropdown_component_spec.rb
+++ b/spec/components/daisy/actions/dropdown_component_spec.rb
@@ -170,6 +170,59 @@ RSpec.describe Daisy::Actions::DropdownComponent, type: :component do
     end
   end
 
+  context "with structured items" do
+    before do
+      render_inline(described_class.new) do |d|
+        d.with_item(label: "Newest", href: "/n", selected: true)
+        d.with_item(href: "/f") do |item|
+          item.with_start { tag.span "S", class: "start-slot" }
+          item.with_end { tag.span "E", class: "end-slot" }
+          "Favorites"
+        end
+      end
+    end
+
+    describe "rendering" do
+      it "renders a labeled link item" do
+        expect(page).to have_css "li.menu-item a[href='/n']", text: "Newest"
+      end
+
+      it "marks the selected item active" do
+        expect(page).to have_css "li.menu-item a[href='/n'].menu-active"
+      end
+
+      it "does not mark unselected items active" do
+        expect(page).to have_css "li.menu-item a[href='/f']:not(.menu-active)"
+      end
+
+      it "renders start and end slots around the label" do
+        expect(page).to have_css "li.menu-item a[href='/f'] .start-slot"
+        expect(page).to have_css "li.menu-item a[href='/f'] .end-slot"
+        expect(page).to have_css "li.menu-item a[href='/f']", text: "Favorites"
+      end
+    end
+  end
+
+  context "mixing a structured item with a plain content item" do
+    before do
+      render_inline(described_class.new) do |d|
+        d.with_item { "Plain" }
+        d.with_item(label: "Structured", selected: true)
+      end
+    end
+
+    describe "rendering" do
+      it "renders the plain content item verbatim, with no link wrapper" do
+        expect(page).to have_css "li.menu-item", text: "Plain"
+        expect(page).not_to have_css "li.menu-item a", text: "Plain"
+      end
+
+      it "renders the structured item as an active row" do
+        expect(page).to have_css "li.menu-item span.menu-active", text: "Structured"
+      end
+    end
+  end
+
   context "with complex configuration" do
     let(:title) { "Complex Dropdown" }
     let(:custom_class) { "custom-dropdown" }


### PR DESCRIPTION
## Context

Part of #165 (theme switcher ergonomics). `daisy_dropdown`'s `with_item` only accepted a generic `<li class="menu-item">` with arbitrary content — there was no affordance for a "selectable row with a leading icon + label + trailing check + active state", so every menu (the theme switcher, app headers, etc.) re-implemented that markup by hand. The issue calls this "probably the highest-leverage small API add."

## Related Issues

Refs #165 (does not close it — one of several ergonomics).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition

## Description

`with_item` now backs onto a nested `ItemComponent` that supports a structured row **opt-in**:

- `label:` — the row's text (or pass it as block content)
- `href:` — renders the row as an `<a>` link
- `selected:` — adds DaisyUI's `menu-active` highlight
- `leading` / `trailing` slots — content before / after the label (icon, checkmark, shortcut hint)

```haml
= daisy_dropdown(title: "Sort by") do |dropdown|
  - dropdown.with_item(label: "Newest", href: "#", selected: true) do |item|
    - item.with_trailing { hero_icon "check", css: "size-4" }
  - dropdown.with_item(label: "Oldest", href: "#")
```

**Backward compatible:** a bare content block (`with_item do … end`, with or without `css:`) renders `<li class="menu-item">…</li>` exactly as before. Structured markup only kicks in when one of the new options/slots is used.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Library suite green (1208 examples, 0 failures), including the existing 22 dropdown specs (backward compat). Dropdowns **and** navbars (which render a dropdown) Playwright specs pass, and the demo page renders the structured rows (`<li class="menu-item"><a class="… menu-active" href="#">`).
