### PR TITLE
feat(ThemeController): Fall back to the applied data-theme in setInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   (`f.daisy_select :branch_id`) showed the first option instead of the record's saved value. Block options now
   default their selected state from the parent `value:`, and an explicit `selected:` on an option still wins.
   Fixes #171.
+- feat(ThemeController): The `loco-theme` controller's `getCurrentTheme` now falls back to the document's
+  applied `data-theme` when nothing is saved in `localStorage`, so `setInput` marks the active row/checkmark
+  on first visit (e.g. a server-rendered or preload-applied theme) instead of leaving every option unmarked
+  until the user picks one. Saved choices still win. Refs #165.
 
 ### Demo / Docs Changes
 

--- a/app/components/daisy/actions/theme_controller.js
+++ b/app/components/daisy/actions/theme_controller.js
@@ -137,9 +137,16 @@ export default class extends Controller {
   }
 
   /**
-   * Retrieves the current theme from localStorage.
+   * Retrieves the current (effective) theme.
    *
-   * @returns {?string} The current theme name, or null if none is saved
+   * Prefers the user's saved choice from localStorage. When nothing is saved
+   * yet — e.g. on a first visit — it falls back to whatever theme is already
+   * applied to the document via the `data-theme` attribute (set by a
+   * server-rendered theme, the `theme_preload_script`, or another controller).
+   * That way the active row / checkmark reflects the theme the user is actually
+   * seeing instead of being left blank until they pick one.
+   *
+   * @returns {?string} The current theme name, or null if none can be determined
    */
   getCurrentTheme() {
     const savedTheme = this.safeStorageGet('savedTheme')
@@ -148,7 +155,7 @@ export default class extends Controller {
       return savedTheme
     }
 
-    return null
+    return document.documentElement.getAttribute('data-theme')
   }
 
   /**

--- a/docs/demo/e2e/daisy/actions/theme_controllers.spec.ts
+++ b/docs/demo/e2e/daisy/actions/theme_controllers.spec.ts
@@ -96,3 +96,20 @@ test('theme-controller inputs have unique ids', async ({ page }) => {
 
   expect(duplicateIds, 'each theme-controller input should have a unique id').toEqual([]);
 });
+
+test('setInput reflects the applied data-theme when nothing is saved', async ({ page }) => {
+  await page.goto(PAGE);
+
+  // Simulate a first visit: a theme is applied to the document (e.g. a
+  // server-rendered data-theme) but the user has not saved a choice yet.
+  await page.evaluate(() => {
+    localStorage.removeItem('savedTheme');
+    document.documentElement.setAttribute('data-theme', 'retro');
+    // Nudge every loco-theme controller to re-sync its inputs (calls setInput).
+    window.dispatchEvent(new CustomEvent('localstorage-update', { detail: { key: 'savedTheme', newValue: null } }));
+  });
+
+  // The radio for the applied theme is now checked even though nothing is saved
+  // — before the fallback, getCurrentTheme() returned null and no row was marked.
+  await expect(page.locator('input.theme-controller[value="retro"]').first()).toBeChecked();
+});


### PR DESCRIPTION
## Context

Part of #165 (theme switcher ergonomics). With themes like `light --default, dark --prefersdark` and no saved choice, `loco-theme`'s `getCurrentTheme()` returned `null`, so `setInput()` matched no input and the active row / checkmark showed nothing — even though a theme is clearly applied. The switcher looked like nothing was selected until the user picked.

## Related Issues

Refs #165 (does not close it — one of several ergonomics).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Description

`getCurrentTheme()` now falls back to the document's `data-theme` attribute when nothing is saved in `localStorage`, so `setInput` marks the active row on first visit when a theme is already applied — a server-rendered `data-theme`, one set by the `theme_preload_script`, or one applied by another controller. A saved choice still wins.

Honest scope note: a theme applied purely by DaisyUI's `--default` / `--prefersdark` CSS (with **no** `data-theme` attribute) still can't be resolved to a theme *name* on the client without knowing the plugin config, so that pristine-first-visit case remains unmarked. This change covers every case where a theme is actually reflected on the element.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Rebuilt the demo JS bundle and ran the full Theme Controllers Playwright suite — all 5 pass, including the new fallback test and the existing "clear theme" / "radio sync" tests (no regression). The new test sets `data-theme` with nothing saved, fires the sync event, and asserts the matching radio becomes checked.
