### PR TITLE
docs(ThemePreview): Fix YARD examples to drop the phantom helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - docs(Fieldset): Add two Fieldsets demo examples for the new caption slot — one using the `caption:` argument
   and one using the `caption` slot with `css: "block"` for a caption containing an inline link — plus a smoke
   check for both in the Playwright spec.
+- docs(ThemePreview): Fix `ThemePreviewComponent`'s YARD examples, which advertised a `daisy_theme_preview`
+  helper that was never registered. They now show the real usage — `tc.build_theme_preview` inside a
+  `daisy_theme_controller`, or rendering the component directly — plus a `@note` that there is no top-level
+  helper. (Follows the decision in #176 not to ship a standalone preview helper.)
 
 ### Fixed
 

--- a/app/components/daisy/actions/theme_preview_component.rb
+++ b/app/components/daisy/actions/theme_preview_component.rb
@@ -6,16 +6,23 @@
 # dots representing the base-content, primary, secondary, and accent colors of
 # the theme.
 #
+# @note There is no top-level `daisy_theme_preview` helper. Render previews
+#   through {Daisy::Actions::ThemeControllerComponent}'s `build_theme_preview`
+#   builder (the usual way, inside a `daisy_theme_controller`), or render the
+#   component directly for a one-off / read-only swatch.
+#
 # @part dot_base The dot showing the base-content color of the theme.
 # @part dot_primary The dot showing the primary color of the theme.
 # @part dot_secondary The dot showing the secondary color of the theme.
 # @part dot_accent The dot showing the accent color of the theme.
 #
-# @loco_example Basic Usage
-#   = daisy_theme_preview(theme: "light")
+# @loco_example Inside a Theme Controller (the usual way)
+#   = daisy_theme_controller do |tc|
+#     - tc.themes.each do |theme|
+#       = tc.build_theme_preview(theme)
 #
-# @loco_example Custom CSS
-#   = daisy_theme_preview(theme: "dark", css: "size-6")
+# @loco_example Rendered directly (read-only swatch, custom size)
+#   = render Daisy::Actions::ThemePreviewComponent.new(theme: "dark", css: "size-6")
 #
 module Daisy
   module Actions


### PR DESCRIPTION
## Context

`ThemePreviewComponent`'s YARD examples advertised a top-level helper:

```haml
= daisy_theme_preview(theme: "light")
```

…which was never registered — so the example didn't actually work. In #176 we decided **not** to ship a standalone `daisy_theme_preview` helper (the switcher will use `build_theme_preview` internally as a ThemeController builder, and the rare standalone case is covered by rendering the component directly). This fixes the docs the lean way instead of making the phantom helper real.

## Related Issues

Follows the decision in #176 (closed). Part of the #165 discussion.

## Type of Change

- [x] Documentation update

## Description

- Rewrote the two `@loco_example`s to show real usage: `tc.build_theme_preview(theme)` inside a `daisy_theme_controller`, and `render Daisy::Actions::ThemePreviewComponent.new(theme:, css:)` for a one-off / read-only swatch.
- Added a `@note` making explicit that there is no top-level `daisy_theme_preview` helper.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Docs-only. `ThemePreviewComponent` spec still 15/15 and rubocop clean.
