### PR TITLE
feat(ThemeController): Add a build_switcher_dropdown builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `.fieldset-label`. Unlike `.label` (`daisy_label`), `.fieldset-label` is not `white-space: nowrap`, so long
   help text wraps instead of pushing the form off-screen. `.fieldset-label` is `display: flex`; for prose with
   an inline link, pass `caption_css: "block"` so the link flows inside the sentence. Fixes #162.
+- feat(ThemeController): Add a `build_switcher_dropdown` builder that renders a complete, working theme
+  switcher in one line — a trigger button plus a menu with a color preview, name, and an active checkmark for
+  every theme, all wired to the `loco-theme` controller. Supports `label:`, `icon:`, `clear:` (a "Clear Theme"
+  row), `name:`, and a `css:` placement. It's a builder method on the existing component (composing
+  `build_radio_input` and `build_theme_preview`), not a new component or subclass. Fixes #165.
 
 ### Demo / Docs Changes
 
@@ -144,6 +149,9 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - docs(Fieldset): Add two Fieldsets demo examples for the new caption slot — one using the `caption:` argument
   and one using the `caption` slot with `css: "block"` for a caption containing an inline link — plus a smoke
   check for both in the Playwright spec.
+- docs(ThemeController): Add a "Switcher Dropdown (Builder)" demo example showing `build_switcher_dropdown`
+  (plain, and with a label + Clear Theme row), plus a Playwright test that picking a theme applies, persists,
+  and marks the active row.
 
 ### Fixed
 

--- a/app/components/daisy/actions/theme_controller_component.rb
+++ b/app/components/daisy/actions/theme_controller_component.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 #
-# The ThemeComponent serves as a foundation for building a full Theme Switcher.
-# It provides the building blocks that you will use such as the Theme Preview,
-# Theme Radio, and Stimulus ThemeController.
+# The ThemeController is the foundation for theme switching. For a complete,
+# ready-made switcher, use the {#build_switcher_dropdown} builder; to build a
+# custom switcher, compose the lower-level builders ({#build_theme_preview},
+# {#build_radio_input}) yourself. Either way it wires up the `loco-theme`
+# Stimulus controller for you.
 #
-# @loco_example Basic Usage
+# @loco_example A complete switcher in one line
+#   = daisy_theme_controller(themes: %w[light dark]) do |tc|
+#     = tc.build_switcher_dropdown
+#
+# @loco_example Composing the lower-level builders
 #   = daisy_theme_controller do |tc|
 #     - tc.themes.each do |theme|
 #       = tc.build_theme_preview(theme)
@@ -100,6 +106,92 @@ module Daisy
           theme: theme,
           **options
         )
+      end
+
+      #
+      # Builder method that renders a complete, ready-to-use theme switcher
+      # dropdown: a trigger button and a menu with one row per theme (a color
+      # preview, the theme name, and a checkmark on the active theme), all wired
+      # to the `loco-theme` controller. Because it is rendered inside this
+      # component, it inherits the `loco-theme` Stimulus controller, so no extra
+      # setup is required.
+      #
+      # @option options [String] :icon The Heroicon name for the trigger button.
+      #   Defaults to "swatch".
+      #
+      # @option options [String] :label Optional text shown beside the trigger
+      #   icon. When omitted, the trigger is an icon-only circle button.
+      #
+      # @option options [Boolean] :clear Whether to append a "Clear Theme" row
+      #   that resets to the default theme. Defaults to false.
+      #
+      # @option options [String] :name The shared `name` for the theme radios.
+      #   Defaults to "theme".
+      #
+      # @option options [String] :css Extra CSS classes for the dropdown (e.g. a
+      #   placement modifier like "dropdown-end"). Defaults to "dropdown-end".
+      #
+      # @return [String] The rendered dropdown.
+      #
+      # @loco_example A one-line theme switcher
+      #   = daisy_theme_controller(themes: %w[light dark synthwave]) do |tc|
+      #     = tc.build_switcher_dropdown
+      #
+      # @loco_example With a label and a Clear Theme row
+      #   = daisy_theme_controller do |tc|
+      #     = tc.build_switcher_dropdown(label: "Theme", clear: true)
+      #
+      def build_switcher_dropdown(icon: "swatch", label: nil, clear: false, name: "theme", css: "dropdown-end")
+        button_css = label ? "btn-ghost" : "btn-ghost btn-circle"
+
+        render(Daisy::Actions::DropdownComponent.new(css: css)) do |dropdown|
+          dropdown.with_button(icon: icon, title: label, css: button_css,
+                               html: { title: "Switch theme", "aria-label": "Switch theme" })
+
+          dropdown.with_item { clear_row(name) } if clear
+
+          themes.each do |theme|
+            dropdown.with_item { switcher_row(theme, name) }
+          end
+        end
+      end
+
+      private
+
+      # Renders a single theme row for {build_switcher_dropdown}: a clickable
+      # link wrapping a hidden `.theme-controller` radio (the `peer` that drives
+      # the checkmark) plus the preview, name, and checkmark. The explicit
+      # `setTheme` action is what makes selection reliable inside a focus
+      # dropdown (a hidden radio's `change` event does not propagate there).
+      def switcher_row(theme, name)
+        parts = [
+          build_radio_input(theme, name: name, css: "hidden peer"),
+          build_theme_preview(theme, css: "size-5"),
+          content_tag(:span, theme.humanize, class: "grow capitalize"),
+          helpers.hero_icon("check", css: "size-4 text-primary invisible peer-checked:visible")
+        ]
+
+        link_to("#", class: "flex items-center gap-3 no-underline",
+                     data: { action: "click->loco-theme#setTheme" }) { safe_join(parts) }
+      end
+
+      # Renders the optional, danger-styled "Clear Theme" row, shown at the top
+      # of the menu. Uses a `<button>` (not a link) because
+      # `loco-theme#clearTheme` does not `preventDefault`, so an `href="#"`
+      # would jump the page. The `themeName` param lets the controller uncheck
+      # this switcher's radios immediately.
+      def clear_row(name)
+        parts = [
+          helpers.hero_icon("trash", css: "size-4"),
+          content_tag(:span, "Clear Theme", class: "grow text-left")
+        ]
+
+        content_tag(:button, type: "button",
+                             class: "flex items-center gap-3 w-full text-error",
+                             data: { action: "loco-theme#clearTheme",
+                                     "loco-theme-theme-name-param": name }) do
+          safe_join(parts)
+        end
       end
     end
   end

--- a/docs/demo/app/views/examples/daisy/actions/theme_controllers.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/theme_controllers.html.haml
@@ -87,6 +87,24 @@
             %span.capitalize= theme.humanize
 
 
+= doc_example(title: "Switcher Dropdown (Builder)", example_css: "pb-64") do |doc|
+  - doc.with_description do
+    :markdown
+      `build_switcher_dropdown` renders a complete, working theme switcher in one
+      line — a trigger button plus a menu with a color preview, name, and a
+      checkmark on the active theme for every theme, all wired to the
+      `loco-theme` controller. Pass `label:`, `icon:`, `clear:`, or a placement
+      via `css:` to customize it. (Everything below is hand-rolled from the
+      sub-components for comparison.)
+
+  .flex.gap-6.items-start
+    = daisy_theme_controller(themes: %w[light dark synthwave retro]) do |theme_controller|
+      = theme_controller.build_switcher_dropdown(css: "dropdown-start", name: "docs-switcher")
+
+    = daisy_theme_controller(themes: %w[light dark synthwave retro]) do |theme_controller|
+      = theme_controller.build_switcher_dropdown(label: "Theme", clear: true, css: "dropdown-start", name: "docs-switcher-labeled")
+
+
 = doc_example(title: "Custom Switcher", example_css: "pb-48") do |doc|
   - doc.with_description do
     :markdown

--- a/docs/demo/e2e/daisy/actions/theme_controllers.spec.ts
+++ b/docs/demo/e2e/daisy/actions/theme_controllers.spec.ts
@@ -12,8 +12,26 @@ test('page loads', async ({ page }) => {
   await loco.expectPageHeadings(page, [
     'Theme Preview Icons',
     'Theme Radio Inputs',
+    'Switcher Dropdown (Builder)',
     'Custom Switcher'
   ]);
+});
+
+test('build_switcher_dropdown switches the theme and marks the active row', async ({ page }) => {
+  await page.goto(PAGE);
+  await page.evaluate(() => localStorage.removeItem('savedTheme'));
+
+  // The first builder switcher's radios are named "docs-switcher". Open it,
+  // then pick "synthwave" (the row's link fires loco-theme#setTheme).
+  const switcher = page.locator('.dropdown', { has: page.locator('input[name="docs-switcher"]') });
+  await switcher.getByRole('button').first().click();
+  await switcher.locator('a:has(input[value="synthwave"])').click();
+
+  // The theme is applied + persisted, and the active row's radio is checked
+  // (which drives its peer-checked checkmark).
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'synthwave');
+  expect(await page.evaluate(() => localStorage.getItem('savedTheme'))).toBe('synthwave');
+  await expect(page.locator('input[name="docs-switcher"][value="synthwave"]')).toBeChecked();
 });
 
 test('clear theme removes data-theme attribute', async ({ page }) => {

--- a/spec/components/daisy/actions/theme_controller_component_spec.rb
+++ b/spec/components/daisy/actions/theme_controller_component_spec.rb
@@ -123,6 +123,51 @@ RSpec.describe Daisy::Actions::ThemeControllerComponent, type: :component do
     end
   end
 
+  describe "#build_switcher_dropdown" do
+    it "renders a dropdown with a trigger and one row per theme" do
+      render_inline(described_class.new(themes: %w[light dark]), &:build_switcher_dropdown)
+
+      expect(page).to have_css("[data-controller='loco-theme'] .dropdown")
+      expect(page).to have_css(".dropdown button.btn") # trigger
+      expect(page).to have_css(".dropdown-content li.menu-item", count: 2)
+      expect(page).to have_css("a[data-action='click->loco-theme#setTheme']", count: 2)
+    end
+
+    it "gives each row a hidden theme-controller radio, a preview, and a name" do
+      render_inline(described_class.new(themes: %w[light dark])) do |tc|
+        tc.build_switcher_dropdown(name: "switch")
+      end
+
+      expect(page).to have_css("input.theme-controller.hidden[name='switch'][value='light']")
+      expect(page).to have_css("[data-theme='light']") # the preview swatch
+      expect(page).to have_css(".dropdown-content", text: "Light")
+      expect(page).to have_css(".dropdown-content", text: "Dark")
+      # checkmark visibility is driven by the radio's checked state
+      expect(page).to have_css("a [class*='peer-checked']")
+    end
+
+    it "shows a danger Clear Theme button at the top when clear: true" do
+      render_inline(described_class.new(themes: %w[light])) do |tc|
+        tc.build_switcher_dropdown(clear: true, name: "switch")
+      end
+
+      # First item, danger-styled, wired to clearTheme with the radio name.
+      expect(page).to have_css(
+        ".dropdown-content li.menu-item:first-child button.text-error[data-action='loco-theme#clearTheme']",
+        text: "Clear Theme"
+      )
+      expect(page).to have_css("button[data-loco-theme-theme-name-param='switch']")
+    end
+
+    it "shows a label on the trigger when given" do
+      render_inline(described_class.new(themes: %w[light])) do |tc|
+        tc.build_switcher_dropdown(label: "Theme")
+      end
+
+      expect(page).to have_css(".dropdown button", text: "Theme")
+    end
+  end
+
   describe "rendering" do
     it "can be rendered with a simple block" do
       render_inline(component) { "Simple test content" }


### PR DESCRIPTION
## Context

The headline ask of #165: a first-class theme switcher, so apps stop copy-pasting the demo header's ~12 lines of dropdown / radio / preview / checkmark boilerplate. Per review, this is a **builder method on the existing `ThemeController`** (right next to `build_radio_input` / `build_theme_preview`) — **not** a subclass or a new registered component.

```haml
= daisy_theme_controller(themes: %w[light dark]) do |tc|
  = tc.build_switcher_dropdown
```

…renders a complete, working switcher: a trigger button plus a menu with a color preview, name, and an active checkmark for every theme, all wired to `loco-theme` (the controller wrapper is already there from `daisy_theme_controller`).

## Related Issues

Fixes #165

The rest of the epic: C ([#175](https://github.com/profoundry-us/loco_motion/pull/175)), D ([#177](https://github.com/profoundry-us/loco_motion/pull/177)), F ([#178](https://github.com/profoundry-us/loco_motion/pull/178)) are merged; B was dropped ([#176](https://github.com/profoundry-us/loco_motion/pull/176), with a small YARD fix in [#188](https://github.com/profoundry-us/loco_motion/pull/188)). This is **A**, the headline.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition

## Description

`build_switcher_dropdown(icon:, label:, clear:, name:, css:)`:

- composes the ergonomics that landed first — `build_radio_input` for the hidden `.theme-controller` `peer` radio, `build_theme_preview` for the swatch,
- relies on the #178 `data-theme` fallback so the active row is marked on first load,
- puts an explicit `click->loco-theme#setTheme` on each row, which is what makes selection reliable in a focus dropdown (a hidden radio's `change` doesn't propagate there),
- `clear: true` adds a "Clear Theme" `<button>` (a button, not a link, because `clearTheme` doesn't `preventDefault`).

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

Library suite green (1223 examples, 0 failures). The Playwright test opens the switcher, picks a theme, and asserts it's applied (`data-theme`), persisted (`localStorage`), and the active row's radio is checked. Verified the rendered DOM directly: a ghost trigger button, then `li.menu-item > a[data-action]` rows each wrapping a hidden `.theme-controller.peer` radio + preview + name + a `peer-checked:visible` checkmark.
