### PR TITLE
docs(Toast): Point dismissal docs at the Alert loco-alert controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   helper that was never registered. They now show the real usage — `tc.build_theme_preview` inside a
   `daisy_theme_controller`, or rendering the component directly — plus a `@note` that there is no top-level
   helper. (Follows the decision in #176 not to ship a standalone preview helper.)
+- docs(Toast): Fix `ToastComponent`'s misleading `@note`, which promised toast show/hide in a "future Stimulus
+  ToastController". Dismissal already ships via the Alert component's `loco-alert` controller, so the note now
+  points at the Alert's `autoclose` / `closable` options (and the required `AlertController` registration), and
+  a new "Auto-dismissing, Closable Toast" `@loco_example` makes that path discoverable. Fixes #185.
 
 ### Fixed
 

--- a/app/components/daisy/feedback/toast_component.rb
+++ b/app/components/daisy/feedback/toast_component.rb
@@ -6,14 +6,22 @@
 # commonly used for temporary notifications, success messages, or error alerts
 # that don't require immediate user action.
 #
-# @note Currently, this component only handles positioning. JavaScript
-#   functionality for showing/hiding toasts will be implemented in a future
-#   Stimulus ToastController.
+# @note This component only handles positioning. For show/hide behavior, use
+#   the {Daisy::Feedback::AlertComponent} options on the alerts inside the
+#   toast — `autoclose` (with `timeout`) auto-dismisses an alert and `closable`
+#   renders a manual close button, both driven by the `loco-alert` Stimulus
+#   controller. As with `loco-theme`, the consuming app must register that
+#   controller (the npm package's `AlertController`) for dismissal to work.
 #
 # @loco_example Basic Toast with Alert
 #   = daisy_toast do
 #     = daisy_alert(icon: "check-circle", css: "alert-success text-white") do
 #       Yay! Something went well!
+#
+# @loco_example Auto-dismissing, Closable Toast
+#   = daisy_toast(css: "toast-top toast-start") do
+#     = daisy_alert(icon: "check-circle", css: "alert-success", autoclose: true, timeout: 4000, closable: true) do
+#       Saved!
 #
 # @loco_example Multiple Alerts in Toast
 #   = daisy_toast do


### PR DESCRIPTION
## Context

`Daisy::Feedback::ToastComponent`'s docs claimed toast show/hide was unimplemented and "coming in a future Stimulus ToastController." That hasn't been true since v0.6.0 — dismissal already ships through the **Alert** component's `loco-alert` controller. Because a toast holds alerts, an auto-dismissing / closable toast works today; the stale note just sent readers looking for something that doesn't exist where they'd expect.

## Related Issues

Fixes #185

## Type of Change

- [x] Documentation update

## Description

Docs-only change to `ToastComponent`:

- Replaced the misleading `@note` so it points at the Alert component's `autoclose` (with `timeout`) and `closable` options — both driven by the `loco-alert` controller — and notes that the consuming app must register `AlertController` (same as `loco-theme`) for dismissal to work.
- Added an "Auto-dismissing, Closable Toast" `@loco_example` so the dismissal path is discoverable straight from the toast docs.
- Added a CHANGELOG entry under Demo / Docs Changes.

No code or behavior changed — `closable` / `autoclose` / `timeout` already exist on `AlertComponent` and are spec-covered.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

The Toast component spec (`spec/components/daisy/feedback/toast_component_spec.rb`) passes unchanged (16 examples, 0 failures). No demo example was added since the change is purely about correcting the YARD note; the dismissal path itself is already exercised by the Alert demos.
