### PR TITLE
feat(CSS): Ship an importable LocoMotion CSS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   bumps the version, and `bin/version-check` (`just version-check`) verifies those two pins alongside
   `version.rb` / `VERSION` / the npm packages — so a stale pin (which silently excludes the new release, like
   `~> 0.5.2` excluding 0.6.0) fails the check instead of shipping.
+- feat(CSS): Ship an importable LocoMotion CSS file — the CSS peer of the npm package's JS controllers —
+  collecting the custom variants (`where`, `dark`) and component-required utility rules (the `floating-sticky`
+  label helper and the keyboard-focus tooltip reveal) that components depend on. Consumers now
+  `@import '@profoundry-us/loco_motion/loco.css'` once instead of hand-copying a growing `@custom-variant`
+  block out of the Install guide, so they stay in sync across upgrades. The file lives at
+  `app/assets/stylesheets/loco.css` (so it ships in the gem automatically) and is exposed to npm through a new
+  `exports` map plus the `files` list; `@import 'tailwindcss'`, the `daisyui` plugin, and `@config` stay in
+  the consumer's own entry since they are app-level choices. The Install and Getting Started guides now point
+  at the import, and the demo consumes the shared file instead of duplicating the rules. Fixes #170.
 
 ### Components Changes
 
@@ -139,9 +148,9 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 - feat(Demo): Add a `floating-sticky` CSS variant that pins a DaisyUI floating label in its raised position
   even while the field is empty and showing a placeholder, so the label and the placeholder hint show at once
   (a Material-style label). Opt in by adding it to the label wrapper, e.g. `daisy_text_input(floating:
-  "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")`. The rule lives in the
-  demo's `application.tailwind.css` for now and is slated to move into the shipped LocoMotion CSS file (#170).
-  Added a "Sticky Floating Label" demo example and a Playwright check that the label stays raised. Fixes #169.
+  "Email", placeholder: "you@example.com", label_wrapper_css: "floating-sticky")`. The rule now ships in the
+  importable LocoMotion CSS file (see the General Changes entry for #170). Added a "Sticky Floating Label" demo
+  example and a Playwright check that the label stays raised. Fixes #169.
 - docs(ThemeController): Add a "Theme Radio with Inline Preview" demo example demonstrating the new
   `build_radio_input` block form (preview + label inside the radio's own label).
 - docs(Dropdown): Add a "Selectable Items" demo example using the new structured `with_item` builder

--- a/app/assets/stylesheets/loco.css
+++ b/app/assets/stylesheets/loco.css
@@ -1,0 +1,78 @@
+/*
+ * LocoMotion — shared CSS
+ * ========================
+ *
+ * The CSS peer of the npm package's JavaScript controllers. Import it once
+ * from your Tailwind entry (after `@import 'tailwindcss'` and the `daisyui`
+ * plugin) to pull in the custom variants and component-required utility rules
+ * that LocoMotion's components depend on:
+ *
+ *   @import 'tailwindcss';
+ *   @plugin 'daisyui';
+ *   @import '@profoundry-us/loco_motion/loco.css';
+ *
+ * Keeping this in one versioned file means you stay in sync across upgrades
+ * instead of hand-copying a growing block out of the Install guide.
+ *
+ * Note: `@import 'tailwindcss'`, the `daisyui` plugin, and your `@config`
+ * content paths are app-level choices and stay in your own entry file — only
+ * the LocoMotion-specific variants and utilities live here.
+ */
+
+/*
+ * `where` variant — wraps a selector in `:where()` so it compiles to a
+ * zero-specificity rule. Components apply their visual defaults through this
+ * variant (e.g. `where:size-6`) so a plain utility you pass via `css:` always
+ * wins. 15+ components rely on it, so it is required, not optional.
+ */
+@custom-variant where (:where(&));
+
+/*
+ * `dark` variant — make `dark:` utilities respond to both an OS-level dark
+ * preference and a DaisyUI ThemeController set to a dark theme, so manual theme
+ * switching and system preference stay in sync.
+ */
+@custom-variant dark (@media (prefers-color-scheme: dark), :root:has(input.theme-controller[value=dark]:checked) &);
+
+/*
+ * Reveal tooltips on keyboard focus when the `tooltip` class is applied
+ * directly to a focusable element (e.g. via LocoMotion's `tip:` attribute on a
+ * button or link). DaisyUI v5 only reveals tooltips through
+ * `:has(:focus-visible)`, which requires the focused element to be a
+ * *descendant* of `.tooltip` — so a tooltip placed on the element itself never
+ * appears on focus. This mirrors DaisyUI's own reveal rule for when the tooltip
+ * element itself is focus-visible.
+ */
+.tooltip:focus-visible:is([data-tip]:not([data-tip=""]), :has(.tooltip-content:not(:empty))) {
+  &[data-tip]::before,
+  &::after,
+  & > .tooltip-content {
+    opacity: 1;
+    --tt-pos: 0rem;
+  }
+}
+
+/*
+ * `floating-sticky` — keep a DaisyUI floating label in its raised position even
+ * while the field is empty and showing a placeholder. By default DaisyUI only
+ * raises the label on focus or once the field has a value (an empty field with
+ * a placeholder matches `:placeholder-shown`, which keeps the label collapsed),
+ * so a placeholder hint and a raised floating label never appear together. Add
+ * `floating-sticky` alongside `floating-label` (e.g. via `label_wrapper_css:`)
+ * to pin the label up, leaving the placeholder visible inside the empty field
+ * for a Material-style label.
+ *
+ * Mirrors DaisyUI's own raised-state declaration; the raised values are
+ * size-independent, so this single rule covers every input size. Because it is
+ * unlayered it also wins over DaisyUI's disabled rule
+ * (`:has(:disabled) > span { opacity: 0 }`), so the label stays visible on
+ * disabled fields too.
+ */
+.floating-label.floating-sticky > span {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 2;
+  top: 0;
+  translate: -12.5% calc(-50% - .125em);
+  scale: .75;
+}

--- a/docs/demo/app/assets/stylesheets/application.tailwind.css
+++ b/docs/demo/app/assets/stylesheets/application.tailwind.css
@@ -10,11 +10,10 @@
   themes: light --default, dark --prefersdark, synthwave, retro, cyberpunk, wireframe;
 }
 
-/* Setup custom variant to reduce selector specificity for component defaults */
-@custom-variant where (:where(&));
-
-/* Setup standard dark: variant to work for both System-based & DaisyUI Theme-based dark mode */
-@custom-variant dark (@media (prefers-color-scheme: dark), :root:has(input.theme-controller[value=dark]:checked) &);
+/* Pull in LocoMotion's custom variants (`where`, `dark`) and component-required
+ * utilities (the tooltip keyboard-focus reveal and `floating-sticky`) from the
+ * shipped CSS file instead of duplicating them here. */
+@import '@profoundry-us/loco_motion/loco.css';
 
 /* Point to our custom config which pulls in some of the LocoMotion files */
 @config "../../../tailwind.config.js";
@@ -31,48 +30,4 @@
 
 .prose {
   max-width: var(--max-prose-width);
-}
-
-/*
- * Reveal tooltips on keyboard focus when the `tooltip` class is applied
- * directly to a focusable element (e.g. via LocoMotion's `tip:` attribute on a
- * button or link). DaisyUI v5 only reveals tooltips through `:has(:focus-visible)`,
- * which requires the focused element to be a *descendant* of `.tooltip` — so a
- * tooltip placed on the element itself never appears on focus. This mirrors
- * DaisyUI's own reveal rule for when the tooltip element itself is focus-visible.
- * See the Getting Started guide for details.
- */
-.tooltip:focus-visible:is([data-tip]:not([data-tip=""]), :has(.tooltip-content:not(:empty))) {
-  &[data-tip]::before,
-  &::after,
-  & > .tooltip-content {
-    opacity: 1;
-    --tt-pos: 0rem;
-  }
-}
-
-/*
- * `floating-sticky` — keep a DaisyUI floating label in its raised position even
- * while the field is empty and showing a placeholder. By default DaisyUI only
- * raises the label on focus or once the field has a value (an empty field with
- * a placeholder matches `:placeholder-shown`, which keeps the label collapsed),
- * so a placeholder hint and a raised floating label never appear together. Add
- * `floating-sticky` alongside `floating-label` (e.g. via `label_wrapper_css:`)
- * to pin the label up, leaving the placeholder visible inside the empty field
- * for a Material-style label.
- *
- * Mirrors DaisyUI's own raised-state declaration; the raised values are
- * size-independent, so this single rule covers every input size. Because it is
- * unlayered it also wins over DaisyUI's disabled rule
- * (`:has(:disabled) > span { opacity: 0 }`), so the label stays visible on
- * disabled fields too. Slated to move into the shipped LocoMotion CSS file
- * (#170); see #169.
- */
-.floating-label.floating-sticky > span {
-  opacity: 1;
-  pointer-events: auto;
-  z-index: 2;
-  top: 0;
-  translate: -12.5% calc(-50% - .125em);
-  scale: .75;
 }

--- a/docs/demo/app/views/docs/02_install.html.haml
+++ b/docs/demo/app/views/docs/02_install.html.haml
@@ -117,14 +117,23 @@
         themes: light --default, dark --prefersdark;
       }
 
-      /* Custom variant to reduce selector specificity for component defaults */
-      @custom-variant where (:where(&));
-
-      /* Custom dark: variant for System-based & DaisyUI ThemeController dark mode */
-      @custom-variant dark (@media (prefers-color-scheme: dark), :root:has(input.theme-controller[value=dark]:checked) &);
+      /* LocoMotion's custom variants (`where`, `dark`) and component-required
+         utilities, shipped as a single versioned file via the npm package. */
+      @import '@profoundry-us/loco_motion/loco.css';
 
       /* Point to tailwind.config.js for content scan paths */
       @config "../tailwind.config.js";
+
+= doc_note(css: "mt-6", title: "Why the @import?") do
+  :markdown
+    `@import '@profoundry-us/loco_motion/loco.css'` pulls in the custom variants
+    and component-required utility rules that LocoMotion's components depend on
+    (the `where` and `dark` variants, the `floating-sticky` label helper, and
+    the keyboard-focus tooltip reveal). It resolves through the
+    `@profoundry-us/loco_motion` npm package you installed above, so you stay in
+    sync across upgrades instead of hand-copying a growing block of CSS. Keep
+    `@import 'tailwindcss'`, the `daisyui` plugin, and `@config` in your own
+    entry — those are app-level choices.
 
 .mt-4.prose
   :markdown

--- a/docs/demo/app/views/guides/01_getting_started.html.haml
+++ b/docs/demo/app/views/guides/01_getting_started.html.haml
@@ -196,8 +196,10 @@
   :markdown
     Then add the Tailwind 4 + DaisyUI directives to your
     `application.tailwind.css` — import Tailwind, register the DaisyUI plugin,
-    and add the `where` and `dark` custom variants. The
-    [Install guide](#{doc_path("install")}) lists the exact CSS block to copy.
+    and import LocoMotion's CSS (`@import '@profoundry-us/loco_motion/loco.css'`),
+    which provides the `where` and `dark` custom variants and the
+    component-required utilities. The [Install guide](#{doc_path("install")})
+    lists the exact CSS block to copy.
 
 = doc_note(modifier: :warning, title: "Tailwind 4 Configuration", css: "mt-6") do
   :markdown
@@ -216,9 +218,11 @@
     placed directly on a focusable element (a button, link, etc.) show on hover
     but not when a keyboard user tabs to them.
 
-    Add this small rule to your `application.tailwind.css` so those tooltips
-    also appear on focus. It mirrors DaisyUI's own reveal rule for the case
-    where the tooltip element itself is focused:
+    LocoMotion's shipped CSS handles this for you: importing
+    `@profoundry-us/loco_motion/loco.css` (per the setup above) includes the
+    rule below, so `tip:` tooltips reveal on keyboard focus automatically — no
+    manual CSS needed. It mirrors DaisyUI's own reveal rule for the case where
+    the tooltip element itself is focused:
 
 .mt-6.max-w-prose
   = doc_code(language: "css") do

--- a/package.json
+++ b/package.json
@@ -9,11 +9,17 @@
   },
   "author": "Topher Fangio",
   "license": "MIT",
+  "exports": {
+    ".": "./index.js",
+    "./loco.css": "./app/assets/stylesheets/loco.css",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2"
   },
   "files": [
     "index.js",
+    "app/assets/stylesheets/loco.css",
     "app/components/daisy/feedback/alert_controller.js",
     "app/components/daisy/data_input/cally_input_controller.js",
     "app/components/daisy/data_display/countdown_controller.js",


### PR DESCRIPTION
## Context

LocoMotion ships its Stimulus controllers as a versioned npm import, but there was no equivalent for CSS. The custom CSS our components rely on — the `where` / `dark` custom variants, plus component-required utilities like `floating-sticky` (#169) and the keyboard-focus tooltip reveal — was handed to consumers as a copy-paste block in the Install guide. That works, but it's hand-synced: consumers re-copy whenever we change it, and the block keeps growing. This ships the CSS peer of the JS package so consumers pull it in with one `@import` and stay in sync across versions.

Follows #169 (so `floating-sticky` is included from the start).

## Related Issues

Fixes #170

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Description

- **New file `app/assets/stylesheets/loco.css`** — the canonical home for LocoMotion's custom variants (`where`, `dark`) and component-required utilities (`floating-sticky`, the tooltip keyboard-focus reveal). Living under `app/` means the gem ships it automatically (the gemspec globs `app/**/*`).
- **`package.json`** — added an `exports` map and listed `loco.css` in `files`, so npm consumers can `@import '@profoundry-us/loco_motion/loco.css'`. The `.` → `index.js` entry preserves the existing controller import contract.
- **Install & Getting Started guides** — replaced the hand-copied `@custom-variant` block with the single import (plus a note on what it pulls in and why `@import 'tailwindcss'` / the `daisyui` plugin / `@config` stay in the consumer's own entry), and noted the tooltip-focus reveal now ships automatically.
- **Demo** — `application.tailwind.css` now consumes the shared file via the real npm path instead of duplicating the rules; only demo-specific styles remain.

## How it was verified

The risky parts are the Tailwind 4 `@import` mechanics and the new `exports` map. Verified in the demo container (same image CI uses):

- **`@import` resolves & variants register**: rebuilt the demo CSS and confirmed the compiled output still contains the `where:` utilities in their **zero-specificity** form (`.where\:absolute { :where(&) { … } }`), the compiled `dark:` rules (using the DaisyUI theme-controller selector), the `floating-sticky` rule, and the tooltip-focus reveal — all now sourced from the imported `loco.css`.
- **`exports` didn't break JS**: the demo's esbuild build still resolves `import { AlertController, … } from "@profoundry-us/loco_motion"` (the `.` entry). Production CSS build also passes.
- **Behavior preserved**: `e2e/daisy/data_input/text_inputs.spec.ts` and `e2e/daisy/feedback/tooltips.spec.ts` pass (4/4) against the rebuilt CSS, and the Install/Getting Started pages render (200) with the new import and without the old copy block.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

**Gem-only consumers**: the file ships in the gem (via the `app/**/*` glob), but the *documented* import path is the npm one. In practice every LocoMotion app already installs the npm package (the JS controllers require it), so a pure-gem `@import` path (which Tailwind can't resolve via `bundle show`) is left as a possible follow-up rather than solved here — flagging it honestly rather than over-claiming.
