### PR TITLE
docs(Iconable): Document icon_options parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   ToastController". Dismissal already ships via the Alert component's `loco-alert` controller, so the note now
   points at the Alert's `autoclose` / `closable` options (and the required `AlertController` registration), and
   a new "Auto-dismissing, Closable Toast" `@loco_example` makes that path discoverable. Fixes #185.
+- docs(Iconable): Document the previously-undocumented `icon_options` / `left_icon_options` /
+  `right_icon_options` parameters on icon-bearing components (Alert, Button, Badge, etc.). These forward
+  options to the underlying `Hero::IconComponent` constructor — most notably `variant: :outline` /
+  `variant: :solid` to pick the icon style — and are distinct from `icon_html`, which sets HTML
+  attributes on the `<svg>`. `icon_options` is the intended way to set icon component options.
 
 ### Fixed
 

--- a/lib/loco_motion/concerns/iconable_component.rb
+++ b/lib/loco_motion/concerns/iconable_component.rb
@@ -28,6 +28,12 @@ module LocoMotion
       # @option kws icon_css   [String] The CSS classes to apply to the icon. This
       #   is an alias of `left_icon_css`.
       #
+      # @option kws icon_options [Hash] Options forwarded to the underlying
+      #   {Hero::IconComponent} constructor — most notably `variant: :outline`
+      #   or `variant: :solid` to pick the icon style. Use this (not
+      #   `icon_html`) for icon component options; `icon_html` is for HTML
+      #   attributes on the `<svg>`. This is an alias of `left_icon_options`.
+      #
       # @option kws icon_html  [Hash] Additional HTML attributes to apply to the
       #   icon. This is an alias of `left_icon_html`.
       #
@@ -37,6 +43,9 @@ module LocoMotion
       # @option kws left_icon_css  [String] The CSS classes to apply to the left
       #   icon.
       #
+      # @option kws left_icon_options [Hash] Options forwarded to the left
+      #   {Hero::IconComponent} constructor (e.g. `variant: :outline`).
+      #
       # @option kws left_icon_html [Hash] Additional HTML attributes to apply to
       #   the left icon.
       #
@@ -45,6 +54,9 @@ module LocoMotion
       #
       # @option kws right_icon_css [String] The CSS classes to apply to the right
       #   icon.
+      #
+      # @option kws right_icon_options [Hash] Options forwarded to the right
+      #   {Hero::IconComponent} constructor (e.g. `variant: :outline`).
       #
       # @option kws right_icon_html [Hash] Additional HTML attributes to apply to
       #   the right icon.


### PR DESCRIPTION
## Context

Investigating a review note on #191: the `icon_options` parameter on icon-bearing components (Alert, Button, Badge, etc.) is implemented and spec-covered but **completely undocumented**. `IconableComponent` initializes `@icon_options` / `@left_icon_options` / `@right_icon_options` and splats them into the `hero_icon(...)` call, yet the concern's YARD only documents `icon`, `icon_css`, and `icon_html` — so there's no way to discover that `icon_options: { variant: :outline }` is how you set the icon's style.

## Related Issues

Surfaced while addressing review feedback on #191.

## Type of Change

- [x] Documentation update

## Description

Added the missing `@option` YARD entries for `icon_options`, `left_icon_options`, and `right_icon_options` to `IconableComponent`. The docs make the distinction explicit: `icon_options` forwards options (most notably `variant: :outline` / `:solid`) to the underlying `Hero::IconComponent` **constructor**, whereas `icon_html` sets HTML attributes on the `<svg>`. `icon_options` is the intended path for icon component options.

## A note on the original hypothesis

The review suspected `icon_html: { variant: :outline }` doesn't work and `icon_options` is required. I verified this in the container, and it's more nuanced:

- `icon_options` being **undocumented** — confirmed, and fixed here.
- `icon_html: { variant: }` being **broken** — not actually the case. Because `IconComponent#call` does `heroicon(@icon, **rendered_html(:component))`, a `variant` passed through `icon_html` still reaches the `heroicon` helper, so `icon_html: { variant: :solid }` and `icon_options: { variant: :solid }` render byte-identical SVG. (The existing Alert/Toast examples pass `variant: :outline`, which is the heroicon **default** anyway, so they're redundant but not wrong.)

So this PR documents the genuinely-missing option and clarifies the intended usage, but deliberately does **not** rewrite the existing examples on a "it's broken" premise that didn't hold up. Happy to follow up with a pass that switches those examples to the semantically-correct `icon_options` (or drops the redundant `variant: :outline`) if you'd like — flagged separately rather than bundled here.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have verified my changes in the browser (if applicable)
- [x] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements
- [x] I have updated the CHANGELOG.md file (if applicable)

## Additional Notes

`icon_options` behavior is already covered by `spec/lib/loco_motion/concerns/iconable_component_spec.rb` (the "with icon_options" context), so this is a docs-only change — concern YARD + CHANGELOG, no behavior change. RuboCop clean; 13 concern examples pass.
