### PR TITLE
docs(Guides): Add install-Just step and document the examples redis service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
   `just dev` without ever telling a brand-new user to install the command runner on their host, so following
   it literally hit `command not found: just`. It now points at `brew install just` / the upstream install
   instructions right after the Docker install.
-- chore(Examples): Drop the unused `redis` service from `examples/docker-compose.yml` (and the `redis`
-  volume and the commented `app` service's `depends_on: redis`). No guide referenced it, so it was an
-  unexplained loose end in the scaffolding new projects copy; easy to add back when an app actually needs it.
+- chore(Examples): Document the `redis` service in `examples/docker-compose.yml`. It was undocumented, so
+  it read as an unexplained loose end; it now carries comments explaining that it's an opt-in convenience
+  for caching / Action Cable / background jobs, how to wire it up (uncomment `- redis` under the `app`
+  service's `depends_on`), and that it's safe to delete if unused.
 - Added publishing auth pre-checks and a Retry / Skip / Abort loop to `bin/release` — before each publish
   the wizard now verifies credentials (`npm whoami` for NPM, a readable `~/.gem/credentials` for RubyGems)
   and, when a pre-check or publish fails, prints the fix (`npm login` / `gem signin`) and re-prompts so you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 
 ### General Changes
 
+- docs(Guides): Add an "install Just" step to the Docker guide's Initial Setup. The guide jumped straight to
+  `just dev` without ever telling a brand-new user to install the command runner on their host, so following
+  it literally hit `command not found: just`. It now points at `brew install just` / the upstream install
+  instructions right after the Docker install.
+- chore(Examples): Drop the unused `redis` service from `examples/docker-compose.yml` (and the `redis`
+  volume and the commented `app` service's `depends_on: redis`). No guide referenced it, so it was an
+  unexplained loose end in the scaffolding new projects copy; easy to add back when an app actually needs it.
 - Added publishing auth pre-checks and a Retry / Skip / Abort loop to `bin/release` — before each publish
   the wizard now verifies credentials (`npm whoami` for NPM, a readable `~/.gem/credentials` for RubyGems)
   and, when a pre-check or publish fails, prints the fix (`npm login` / `gem signin`) and re-prompts so you

--- a/docs/demo/app/views/guides/01_docker.html.haml
+++ b/docs/demo/app/views/guides/01_docker.html.haml
@@ -23,7 +23,14 @@
     First, you'll need to install Docker. You can download it from
     [Docker's website](https://www.docker.com/).
 
-    Once installed, create a new directory for your project:
+    You'll also need [Just](https://github.com/casey/just), the command
+    runner we use for every shortcut in the `justfile`. Install it with your
+    package manager — for example `brew install just` on macOS — or follow
+    the
+    [installation instructions](https://github.com/casey/just#installation)
+    for other platforms.
+
+    Once both are installed, create a new directory for your project:
 
 .max-w-prose
   = daisy_code(css: "my-4") do |code|

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -8,12 +8,6 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 
-  redis:
-    image: redis:7-alpine
-    command: redis-server
-    volumes:
-      - 'redis:/data'
-
   dev:
     build: ./dev/
     volumes:
@@ -31,8 +25,6 @@ services:
   #   stdin_open: true
   #   depends_on:
   #     - db
-  #     - redis
 
 volumes:
   postgres:
-  redis:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -8,6 +8,17 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 
+  # Redis is here for convenience — many Rails apps eventually want it for
+  # caching, Action Cable, or a background-job queue (Sidekiq, Resque, etc.).
+  # It is NOT required to boot the app. When you wire it up, uncomment the
+  # `- redis` line under the `app` service's `depends_on` below and point your
+  # app at `redis://redis:6379`. Delete this service if you don't need it.
+  redis:
+    image: redis:7-alpine
+    command: redis-server
+    volumes:
+      - 'redis:/data'
+
   dev:
     build: ./dev/
     volumes:
@@ -25,6 +36,8 @@ services:
   #   stdin_open: true
   #   depends_on:
   #     - db
+  #     - redis  # uncomment once your app actually uses Redis
 
 volumes:
   postgres:
+  redis:


### PR DESCRIPTION
## Context

Reviewing the onboarding guides against the freshly-refreshed `examples/` scaffolding (post #194) surfaced two small loose ends: the Docker guide never tells a new user to install Just before it asks them to run `just dev`, and the example `docker-compose.yml` ships a `redis` service with no explanation of what it's for.

## Type of Change

- [x] Documentation update
- [x] Other: example scaffolding cleanup

## Description

**Add an "install Just" step to the Docker guide.** §1 Initial Setup installed Docker and then jumped straight to `just dev` in §3, with nothing in between telling the host to install the command runner. Following the guide literally produced `command not found: just`. It now points at `brew install just` (and the upstream install instructions for other platforms) right after the Docker install.

**Document the `redis` service in `examples/docker-compose.yml`.** Originally I removed it, but per review feedback it's kept — it now carries comments explaining that it's an opt-in convenience (caching / Action Cable / background jobs), how to wire it up (uncomment `- redis` under the `app` service's `depends_on`), and that it's safe to delete if unused.

## How it was verified

`examples/docker-compose.yml` still parses and contains `db`, `redis`, and `dev` (plus the commented `app`). Docs-only change otherwise — no source/library code touched, so the component suites are unaffected.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)