### PR TITLE
feat(Linkable): Add Turbo data-attribute options to linkable components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ We plan to use patch versions only for bug fixes, and for now, all **minor relea
 
 ### General Changes
 
+- feat(Linkable): Add first-class `turbo_frame`, `turbo_method`, and `turbo_confirm` options to every linkable
+  component (anything that already takes `href:` — buttons, links, cards, badges, etc.). They map to the
+  `data-turbo-frame` / `data-turbo-method` / `data-turbo-confirm` attributes, so common Turbo patterns no
+  longer need a hand-written `html: { data: { … } }` hash — `daisy_button("Delete", href: thing_path,
+  turbo_method: :delete, turbo_confirm: "Are you sure?")` instead. Implemented as a small `TurboableComponent`
+  concern that `LinkableComponent` pulls in, mirroring how `TippableComponent` sugars `tip` over `data-tip`;
+  each attribute is emitted only when provided, and an explicit `html: { data: { … } }` value still wins.
+  Fixes #202.
 - docs(Guides): Add an "install Just" step to the Docker guide's Initial Setup. The guide jumped straight to
   `just dev` without ever telling a brand-new user to install the command runner on their host, so following
   it literally hit `command not found: just`. It now points at `brew install just` / the upstream install

--- a/docs/demo/app/views/examples/daisy/actions/buttons.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/buttons.html.haml
@@ -49,6 +49,21 @@
       Link with Icon
 
 
+= doc_example(title: "Turbo Attributes") do |doc|
+  - doc.with_description do
+    :markdown
+      Link buttons accept first-class `turbo_frame`, `turbo_method`, and
+      `turbo_confirm` options that map to the corresponding `data-turbo-*`
+      attributes, so you don't have to hand-write a nested
+      `html: { data: { ... } }` hash for common Turbo patterns.
+
+  .my-2.flex.flex-col.lg:flex-row.gap-4
+    = daisy_button(href: "/docs", css: "btn-primary", turbo_frame: "modal") do
+      Open in Frame
+
+    = daisy_button(href: "#", css: "btn-error", turbo_method: :delete, turbo_confirm: "Are you sure?") do
+      Delete
+
 
 = doc_example(title: "Icon Buttons") do |doc|
   - doc.with_description do

--- a/docs/plans/202606-2-turboable-component.md
+++ b/docs/plans/202606-2-turboable-component.md
@@ -1,0 +1,210 @@
+# Add a TurboableComponent Concern (Turbo data-attribute sugar)
+
+
+## Overview
+
+Add a `LocoMotion::Concerns::TurboableComponent` concern that gives linkable
+components first-class keyword options for the three most common Turbo data
+attributes:
+
+| Option           | Emitted attribute     |
+|------------------|-----------------------|
+| `turbo_frame:`   | `data-turbo-frame`    |
+| `turbo_method:`  | `data-turbo-method`   |
+| `turbo_confirm:` | `data-turbo-confirm`  |
+
+This mirrors how `TippableComponent` already sugars `tip:` over `data-tip`,
+removing the verbose `html: { data: { turbo_frame: "modal" } }` boilerplate at
+call sites. The concern is included wherever `LinkableComponent` is already
+included, since these attributes are only meaningful on link/button elements.
+
+Fixes #202.
+
+
+## External Resources
+
+- Issue: https://github.com/profoundry-us/loco_motion/issues/202
+- Turbo data attributes:
+  https://turbo.hotwired.dev/reference/attributes
+- Pattern reference: `lib/loco_motion/concerns/tippable_component.rb`
+
+
+## Key Findings From Investigation
+
+- **Precedence is free.** Rendered HTML is `default_html.deep_merge(user_html)`
+  (`lib/loco_motion/base_component.rb:326`). `add_html` writes to
+  `default_html` (`lib/loco_motion/component_config.rb:114`), while an explicit
+  `html: { data: { … } }` lands in `user_html`
+  (`lib/loco_motion/component_config.rb:57`). So a hand-written
+  `data-turbo-frame` automatically wins over the concern's value — no special
+  handling needed to honor the "explicit still takes precedence" requirement.
+
+- **`LinkableComponent` is included by 11 components**, all of which should pick
+  up the new concern:
+  `Daisy::Actions::ButtonComponent`, `Daisy::DataDisplay::AvatarComponent`,
+  `Daisy::DataDisplay::BadgeComponent`, `Daisy::DataDisplay::CardComponent`,
+  `Daisy::DataDisplay::FigureComponent`, `Daisy::DataDisplay::StatComponent`,
+  `Daisy::DataDisplay::TextRotateComponent`,
+  `Daisy::Feedback::AlertComponent`, `Daisy::Layout::HoverComponent`,
+  `Daisy::Navigation::DockComponent`, `Daisy::Navigation::LinkComponent`.
+
+- **Concerns get their own isolated spec** under
+  `spec/lib/loco_motion/concerns/`, using a small test component that includes
+  the concern (see `tippable_component_spec.rb`). The new concern follows the
+  same shape.
+
+- **Decision: separate concern, pulled in by `LinkableComponent`.** A distinct
+  `TurboableComponent` keeps the concern single-purpose and independently
+  testable (matching the existing `Tippable` / `Iconable` split). Rather than
+  adding `include` lines to all 11 components — which would touch 5 component
+  groups and blow the 10-file PR limit — `LinkableComponent` itself does
+  `base.include(TurboableComponent)` in its `included` hook. Turbo data
+  attributes only make sense on link/button elements, so coupling them to the
+  linkable concern is semantically correct (this is the "fold into
+  `LinkableComponent`" option the issue offered, without losing a separately
+  testable module). Every component that already includes `LinkableComponent`
+  gets the sugar for free, and the change touches one library file instead of
+  eleven.
+
+
+## Implementation Steps
+
+### 1. Add the TurboableComponent concern
+
+**Purpose**: Provide the `turbo_frame:` / `turbo_method:` / `turbo_confirm:`
+options and translate them into `data-turbo-*` attributes.
+
+**File to Create**: `lib/loco_motion/concerns/turboable_component.rb`
+
+**Reference Files**:
+- `lib/loco_motion/concerns/tippable_component.rb`
+- `lib/loco_motion/concerns/linkable_component.rb`
+
+**Changes to Make**:
+
+Mirror `TippableComponent`: register an initializer that reads the three
+options via `config_option`, and a setup hook that builds a `data` hash and
+calls `add_html(:component, { data: data })` only when at least one option is
+present (no empty `data-*` attributes). Include full YARD with an `@option`
+entry per option (blank line between each), per project doc conventions.
+
+```ruby
+def _initialize_turboable_component
+  @turbo_frame   = config_option(:turbo_frame)
+  @turbo_method  = config_option(:turbo_method)
+  @turbo_confirm = config_option(:turbo_confirm)
+end
+
+def _setup_turboable_component
+  data = {}
+  data[:turbo_frame]   = @turbo_frame   if @turbo_frame
+  data[:turbo_method]  = @turbo_method  if @turbo_method
+  data[:turbo_confirm] = @turbo_confirm if @turbo_confirm
+  add_html(:component, { data: data }) if data.any?
+end
+```
+
+### 2. Pull the concern in via LinkableComponent
+
+**Purpose**: Wire the sugar into every component that already renders a link,
+without editing all 11 of them.
+
+**File to Edit**: `lib/loco_motion/concerns/linkable_component.rb`
+
+**Changes to Make**:
+
+In the `included do |base|` hook, add `base.include(TurboableComponent)` so any
+component including `LinkableComponent` also picks up `TurboableComponent`'s
+initializer/setup. Update the concern's class-level YARD to mention the
+inherited `turbo_*` options. The `TurboableComponent` constant autoloads on
+reference (same as `Tippable` / `Iconable`), so no explicit `require` is added.
+
+### 3. Add the concern spec
+
+**Purpose**: Verify each attribute is emitted only when provided, and that an
+explicit `html: { data: { … } }` value overrides the sugar.
+
+**File to Create**:
+`spec/lib/loco_motion/concerns/turboable_component_spec.rb`
+
+**Changes to Make**:
+
+Follow `tippable_component_spec.rb`: define a `TurboableTestComponent` that
+includes the concern, then cover:
+
+- No options → none of the `data-turbo-*` attributes render.
+- Each option individually → only that attribute renders, with the right value.
+- All three together → all three render.
+- Explicit `html: { data: { turbo_frame: "x" } }` alongside `turbo_frame: "y"`
+  → the explicit `"x"` wins (precedence guard).
+
+### 4. Add a smoke test on one real component
+
+**Purpose**: Confirm the concern actually reaches a shipping component.
+
+**File to Edit**: `spec/components/daisy/actions/button_component_spec.rb`
+
+**Changes to Make**:
+
+Add a short context (mirroring the existing "with tooltip" context at
+`button_component_spec.rb:160`) asserting
+`daisy_button("X", href: "/y", turbo_frame: "modal")` renders
+`a[data-turbo-frame='modal']`.
+
+### 5. Document an example
+
+**Purpose**: Make the new options discoverable in the demo.
+
+**File to Edit**:
+`docs/demo/app/views/examples/daisy/actions/buttons.html.haml` (or the closest
+existing Button example view).
+
+**Changes to Make**:
+
+Add one `@loco_example`-style demo (HAML, `daisy_` helper) showing a button
+with `turbo_frame:` / `turbo_method:` / `turbo_confirm:`. Keep it minimal — a
+single representative call, not a variant matrix.
+
+### 6. Update the CHANGELOG
+
+**Purpose**: Record the new feature.
+
+**File to Edit**: `CHANGELOG.md` (wrap at 110)
+
+**Changes to Make**:
+
+Add a `feat(...)` entry under `## [Unreleased]` → General Changes describing the
+new `turbo_frame:` / `turbo_method:` / `turbo_confirm:` options and that they
+apply to all linkable components. Append `Fixes #202`.
+
+### 7. Verification Steps
+
+**Purpose**: Confirm the concern works and nothing regressed.
+
+**Commands to Run**:
+```bash
+just loco-test
+```
+
+**Expected Results**:
+
+The new concern spec and the Button smoke test pass; the existing suite stays
+green.
+
+
+## Scope / PR Split
+
+This is a single logical concern (the Turbo sugar) and should stay one PR, but
+mind the repo's 500-line / 10-file limit. The concern + spec + CHANGELOG +
+example is small; the 11 `include` lines are one line each. If the YARD/doc
+churn pushes it over the file limit, split as: **(1)** concern + spec +
+wire-in, **(2)** demo example + docs — landing the concern first.
+
+
+## Open Questions
+
+- Confirm `turbo_method:` should map to `data-turbo-method` (current Turbo),
+  not legacy `data-method`. The issue specifies the former; implement that.
+- Whether to also expose `turbo_action:`, `turbo_stream:`, or
+  `turbo_prefetch:` later — out of scope here; the concern is trivially
+  extendable when a need shows up.

--- a/lib/loco_motion/concerns/linkable_component.rb
+++ b/lib/loco_motion/concerns/linkable_component.rb
@@ -8,10 +8,16 @@ module LocoMotion
     # Include this module to enable link functionality in a component.
     # When an href is provided, the component will render as an <a> tag.
     #
+    # Also pulls in {TurboableComponent} so every linkable component gains the
+    # `turbo_frame`, `turbo_method`, and `turbo_confirm` options for free —
+    # those Turbo data attributes only make sense on link/button elements.
+    #
     module LinkableComponent
       extend ActiveSupport::Concern
 
       included do |base|
+        base.include(LocoMotion::Concerns::TurboableComponent)
+
         base.register_component_initializer(:_initialize_linkable_component)
         base.register_component_setup(:_setup_linkable_component)
       end

--- a/lib/loco_motion/concerns/turboable_component.rb
+++ b/lib/loco_motion/concerns/turboable_component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module LocoMotion
+  module Concerns
+    #
+    # Can be included in linkable components to provide first-class keyword
+    # options for the most common Turbo data attributes, instead of
+    # hand-writing the nested `html: { data: { ... } }` hash. This mirrors the
+    # way {TippableComponent} sugars `tip` over `data-tip`.
+    #
+    # | Option           | Emitted attribute    |
+    # |------------------|----------------------|
+    # | `turbo_frame`    | `data-turbo-frame`   |
+    # | `turbo_method`   | `data-turbo-method`  |
+    # | `turbo_confirm`  | `data-turbo-confirm` |
+    #
+    # Each attribute is only emitted when its option is provided, and anything
+    # passed explicitly via `html: { data: { ... } }` still takes precedence
+    # (user HTML is deep-merged over these defaults).
+    #
+    module TurboableComponent
+      extend ActiveSupport::Concern
+
+      included do |base|
+        base.register_component_initializer(:_initialize_turboable_component)
+        base.register_component_setup(:_setup_turboable_component)
+      end
+
+      protected
+
+      #
+      # Initialize Turbo-related options.
+      #
+      # @option kws turbo_frame [String] The Turbo Frame to target, rendered as
+      #   `data-turbo-frame`.
+      #
+      # @option kws turbo_method [String, Symbol] The HTTP method Turbo should
+      #   use for the request, rendered as `data-turbo-method` (e.g. `:delete`).
+      #
+      # @option kws turbo_confirm [String] A confirmation prompt Turbo shows
+      #   before submitting, rendered as `data-turbo-confirm`.
+      #
+      def _initialize_turboable_component
+        @turbo_frame = config_option(:turbo_frame)
+        @turbo_method = config_option(:turbo_method)
+        @turbo_confirm = config_option(:turbo_confirm)
+      end
+
+      #
+      # Configure Turbo functionality for the component. Adds each
+      # `data-turbo-*` attribute only when its corresponding option was
+      # provided, so no empty attributes are rendered.
+      #
+      def _setup_turboable_component
+        data = {}
+        data[:turbo_frame] = @turbo_frame if @turbo_frame
+        data[:turbo_method] = @turbo_method if @turbo_method
+        data[:turbo_confirm] = @turbo_confirm if @turbo_confirm
+
+        add_html(:component, { data: data }) if data.any?
+      end
+    end
+  end
+end

--- a/spec/components/daisy/actions/button_component_spec.rb
+++ b/spec/components/daisy/actions/button_component_spec.rb
@@ -170,4 +170,26 @@ RSpec.describe Daisy::Actions::ButtonComponent, type: :component do
       end
     end
   end
+
+  context "with turbo options" do
+    let(:button) do
+      described_class.new(
+        href: "/things/1",
+        turbo_frame: "modal",
+        turbo_method: :delete,
+        turbo_confirm: "Are you sure?"
+      )
+    end
+
+    before do
+      render_inline(button)
+    end
+
+    describe "rendering" do
+      it "includes the turbo data attributes on the link" do
+        expect(page).to have_css "a[href='/things/1'][data-turbo-frame='modal']" \
+                                 "[data-turbo-method='delete'][data-turbo-confirm='Are you sure?']"
+      end
+    end
+  end
 end

--- a/spec/lib/loco_motion/concerns/turboable_component_spec.rb
+++ b/spec/lib/loco_motion/concerns/turboable_component_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Test class that includes the concern
+class TurboableTestComponent < LocoMotion::BaseComponent
+  include LocoMotion::Concerns::TurboableComponent
+
+  def call
+    part(:component) { "Test Content" }
+  end
+
+  def before_render
+    setup_component
+    super
+  end
+
+  def setup_component
+    set_tag_name(:component, :div)
+    add_css(:component, "test-component")
+  end
+end
+
+RSpec.describe LocoMotion::Concerns::TurboableComponent, type: :component do
+  context "without any turbo options" do
+    before do
+      render_inline(TurboableTestComponent.new)
+    end
+
+    it "renders no turbo data attributes" do
+      expect(page).to have_css("div.test-component")
+      expect(page).not_to have_css("[data-turbo-frame]")
+      expect(page).not_to have_css("[data-turbo-method]")
+      expect(page).not_to have_css("[data-turbo-confirm]")
+    end
+  end
+
+  context "with turbo_frame" do
+    before do
+      render_inline(TurboableTestComponent.new(turbo_frame: "modal"))
+    end
+
+    it "sets only the data-turbo-frame attribute" do
+      expect(page).to have_css("div.test-component[data-turbo-frame='modal']")
+      expect(page).not_to have_css("[data-turbo-method]")
+      expect(page).not_to have_css("[data-turbo-confirm]")
+    end
+  end
+
+  context "with turbo_method" do
+    before do
+      render_inline(TurboableTestComponent.new(turbo_method: :delete))
+    end
+
+    it "sets only the data-turbo-method attribute" do
+      expect(page).to have_css("div.test-component[data-turbo-method='delete']")
+      expect(page).not_to have_css("[data-turbo-frame]")
+      expect(page).not_to have_css("[data-turbo-confirm]")
+    end
+  end
+
+  context "with turbo_confirm" do
+    before do
+      render_inline(TurboableTestComponent.new(turbo_confirm: "Are you sure?"))
+    end
+
+    it "sets only the data-turbo-confirm attribute" do
+      expect(page).to have_css("div.test-component[data-turbo-confirm='Are you sure?']")
+      expect(page).not_to have_css("[data-turbo-frame]")
+      expect(page).not_to have_css("[data-turbo-method]")
+    end
+  end
+
+  context "with all three turbo options" do
+    before do
+      render_inline(TurboableTestComponent.new(
+                      turbo_frame: "modal",
+                      turbo_method: :delete,
+                      turbo_confirm: "Are you sure?"
+                    ))
+    end
+
+    it "sets all three data-turbo attributes" do
+      expect(page).to have_css("[data-turbo-frame='modal']")
+      expect(page).to have_css("[data-turbo-method='delete']")
+      expect(page).to have_css("[data-turbo-confirm='Are you sure?']")
+    end
+  end
+
+  context "with an explicit html data attribute" do
+    before do
+      render_inline(TurboableTestComponent.new(
+                      turbo_frame: "sugar",
+                      html: { data: { turbo_frame: "explicit" } }
+                    ))
+    end
+
+    it "lets the explicit html value take precedence over the option" do
+      expect(page).to have_css("[data-turbo-frame='explicit']")
+      expect(page).not_to have_css("[data-turbo-frame='sugar']")
+    end
+  end
+
+  context "with turbo options and additional HTML attributes" do
+    before do
+      render_inline(TurboableTestComponent.new(
+                      turbo_frame: "modal",
+                      html: { id: "custom-component", data: { test: "value" } }
+                    ))
+    end
+
+    it "preserves other HTML attributes alongside the turbo attribute" do
+      expect(page).to have_css("div.test-component#custom-component[data-test='value'][data-turbo-frame='modal']")
+    end
+  end
+end


### PR DESCRIPTION
## Context

Targeting a Turbo Frame — or setting a Turbo method/confirm — from a component meant hand-writing a nested `html: { data: { … } }` hash, which is verbose and easy to get subtly wrong for some of the most common Turbo patterns in a Rails app. This adds first-class keyword options that read much better and match the ergonomics LocoMotion already provides for tooltips (`tip:` → `data-tip`) and links (`href:`). Requested in #202 (found in the wild on FAB actions in a consuming app).

## Description

- New `LocoMotion::Concerns::TurboableComponent` providing `turbo_frame:`, `turbo_method:`, and `turbo_confirm:` options that map to the `data-turbo-frame` / `data-turbo-method` / `data-turbo-confirm` attributes. Mirrors `TippableComponent`: each attribute is emitted only when its option is provided, and an explicit `html: { data: { … } }` value still takes precedence (user HTML deep-merges over these defaults).
- `LinkableComponent` pulls the concern in via `base.include(...)` in its `included` hook, so every component that already takes `href:` (buttons, links, cards, badges, avatars, figures, stats, alerts, etc.) gains the options for free. These attributes only make sense on link/button elements, so coupling them to the linkable concern is semantically correct — and it touches one library file instead of adding an `include` line to all 11 linkable components (which would span 5 component groups and exceed the PR file limit).
- New concern spec covering: no attributes when unset, each attribute in isolation, all three together, explicit-html precedence, and coexistence with other HTML attributes. Plus a Button smoke test confirming the options reach a real component.
- "Turbo Attributes" demo example on the Buttons page.

Before:

```haml
= daisy_button("Delete", href: thing_path, html: { data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } })
```

After:

```haml
= daisy_button("Delete", href: thing_path, turbo_method: :delete, turbo_confirm: "Are you sure?")
```

Verified with `just loco-test` (1232 examples, 0 failures), the demo suite (72 examples, 0 failures), and RuboCop (no offenses on changed files).

## Related Issues

Fixes #202

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added appropriate YARD documentation
- [x] I have updated the CHANGELOG.md file

🤖 Generated with [Claude Code](https://claude.com/claude-code)